### PR TITLE
feat: spec-complete Number and Math builtins

### DIFF
--- a/crates/stator_core/src/builtins/global.rs
+++ b/crates/stator_core/src/builtins/global.rs
@@ -583,8 +583,9 @@ mod tests {
 
     #[test]
     fn test_global_parse_float_infinity() {
-        assert_eq!(global_parse_float("inf"), f64::INFINITY);
-        assert_eq!(global_parse_float("-inf"), f64::NEG_INFINITY);
+        // ECMAScript only recognises "Infinity" (capital I), not "inf".
+        assert_eq!(global_parse_float("Infinity"), f64::INFINITY);
+        assert_eq!(global_parse_float("-Infinity"), f64::NEG_INFINITY);
     }
 
     // ── global_encode_uri ────────────────────────────────────────────────────

--- a/crates/stator_core/src/builtins/install_globals.rs
+++ b/crates/stator_core/src/builtins/install_globals.rs
@@ -29,10 +29,11 @@ use crate::builtins::global::{
 };
 use crate::builtins::math::{
     MATH_E, MATH_LN2, MATH_LN10, MATH_LOG2E, MATH_LOG10E, MATH_PI, MATH_SQRT1_2, MATH_SQRT2,
-    math_abs, math_acos, math_asin, math_atan, math_atan2, math_cbrt, math_ceil, math_clz32,
-    math_cos, math_floor, math_fround, math_hypot, math_imul, math_log, math_log2, math_log10,
-    math_max, math_min, math_pow, math_random, math_round, math_sign, math_sin, math_sqrt,
-    math_tan, math_trunc,
+    math_abs, math_acos, math_acosh, math_asin, math_asinh, math_atan, math_atan2, math_atanh,
+    math_cbrt, math_ceil, math_clz32, math_cos, math_cosh, math_exp, math_expm1, math_floor,
+    math_fround, math_hypot, math_imul, math_log, math_log1p, math_log2, math_log10, math_max,
+    math_min, math_pow, math_random, math_round, math_sign, math_sin, math_sinh, math_sqrt,
+    math_tan, math_tanh, math_trunc,
 };
 use crate::builtins::symbol::{
     SYMBOL_ASYNC_ITERATOR, SYMBOL_HAS_INSTANCE, SYMBOL_IS_CONCAT_SPREADABLE, SYMBOL_ITERATOR,
@@ -195,6 +196,42 @@ fn make_math() -> JsValue {
     props.insert(
         "atan".into(),
         native(|args| Ok(num(math_atan(arg_f64(&args, 0)?)))),
+    );
+    props.insert(
+        "sinh".into(),
+        native(|args| Ok(num(math_sinh(arg_f64(&args, 0)?)))),
+    );
+    props.insert(
+        "cosh".into(),
+        native(|args| Ok(num(math_cosh(arg_f64(&args, 0)?)))),
+    );
+    props.insert(
+        "tanh".into(),
+        native(|args| Ok(num(math_tanh(arg_f64(&args, 0)?)))),
+    );
+    props.insert(
+        "asinh".into(),
+        native(|args| Ok(num(math_asinh(arg_f64(&args, 0)?)))),
+    );
+    props.insert(
+        "acosh".into(),
+        native(|args| Ok(num(math_acosh(arg_f64(&args, 0)?)))),
+    );
+    props.insert(
+        "atanh".into(),
+        native(|args| Ok(num(math_atanh(arg_f64(&args, 0)?)))),
+    );
+    props.insert(
+        "exp".into(),
+        native(|args| Ok(num(math_exp(arg_f64(&args, 0)?)))),
+    );
+    props.insert(
+        "expm1".into(),
+        native(|args| Ok(num(math_expm1(arg_f64(&args, 0)?)))),
+    );
+    props.insert(
+        "log1p".into(),
+        native(|args| Ok(num(math_log1p(arg_f64(&args, 0)?)))),
     );
     props.insert(
         "fround".into(),
@@ -404,6 +441,21 @@ fn make_number() -> JsValue {
             Ok(JsValue::Boolean(result))
         }),
     );
+    // Number.isSafeInteger
+    props.insert(
+        "isSafeInteger".into(),
+        native(|args| {
+            let val = args.first().unwrap_or(&JsValue::Undefined);
+            let result = match val {
+                JsValue::Smi(_) => true,
+                JsValue::HeapNumber(n) => {
+                    n.is_finite() && n.fract() == 0.0 && n.abs() <= 9_007_199_254_740_991.0
+                }
+                _ => false,
+            };
+            Ok(JsValue::Boolean(result))
+        }),
+    );
     // Number.parseInt
     props.insert(
         "parseInt".into(),
@@ -436,7 +488,7 @@ fn make_number() -> JsValue {
         JsValue::HeapNumber(-9_007_199_254_740_991.0),
     );
     props.insert("MAX_VALUE".into(), JsValue::HeapNumber(f64::MAX));
-    props.insert("MIN_VALUE".into(), JsValue::HeapNumber(f64::MIN_POSITIVE));
+    props.insert("MIN_VALUE".into(), JsValue::HeapNumber(5e-324));
     props.insert("EPSILON".into(), JsValue::HeapNumber(f64::EPSILON));
     props.insert(
         "POSITIVE_INFINITY".into(),

--- a/crates/stator_core/src/builtins/math.rs
+++ b/crates/stator_core/src/builtins/math.rs
@@ -101,7 +101,7 @@ pub fn math_floor(x: f64) -> f64 {
 /// ECMAScript §21.3.2.28 `Math.round(x)`.
 ///
 /// Returns the integer nearest to `x`, rounding half-way cases toward
-/// `+Infinity` (i.e. `0.5` rounds to `1`, `-0.5` rounds to `0`).
+/// `+Infinity` (i.e. `0.5` rounds to `1`, `-0.5` rounds to `-0`).
 ///
 /// # Examples
 ///
@@ -113,9 +113,13 @@ pub fn math_floor(x: f64) -> f64 {
 /// assert_eq!(math_round(1.4), 1.0);
 /// ```
 pub fn math_round(x: f64) -> f64 {
-    // ECMAScript §21.3.2.28: ties round toward +Infinity, equivalent to
-    // floor(x + 0.5).
-    (x + 0.5).floor()
+    let rounded = (x + 0.5).floor();
+    // ECMAScript §21.3.2.28: values in [-0.5, -0] must return -0.
+    if rounded == 0.0 && x.is_sign_negative() {
+        -0.0_f64
+    } else {
+        rounded
+    }
 }
 
 // ── Math.trunc ────────────────────────────────────────────────────────────────
@@ -189,7 +193,8 @@ pub fn math_max(values: &[f64]) -> f64 {
         if v.is_nan() {
             return f64::NAN;
         }
-        if v > result {
+        // ECMAScript: +0 is greater than -0.
+        if v > result || (v == 0.0 && result == 0.0 && result.is_sign_negative()) {
             result = v;
         }
     }
@@ -216,7 +221,8 @@ pub fn math_min(values: &[f64]) -> f64 {
         if v.is_nan() {
             return f64::NAN;
         }
-        if v < result {
+        // ECMAScript: -0 is less than +0.
+        if v < result || (v == 0.0 && result == 0.0 && v.is_sign_negative()) {
             result = v;
         }
     }
@@ -571,6 +577,162 @@ pub fn math_fround(x: f64) -> f64 {
     (x as f32) as f64
 }
 
+// ── Math.exp ──────────────────────────────────────────────────────────────────
+
+/// ECMAScript §21.3.2.14 `Math.exp(x)`.
+///
+/// Returns *e* raised to the power `x`.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::math::math_exp;
+///
+/// assert!((math_exp(0.0) - 1.0).abs() < 1e-15);
+/// assert!((math_exp(1.0) - std::f64::consts::E).abs() < 1e-14);
+/// assert!(math_exp(f64::NAN).is_nan());
+/// ```
+pub fn math_exp(x: f64) -> f64 {
+    x.exp()
+}
+
+// ── Math.expm1 ────────────────────────────────────────────────────────────────
+
+/// ECMAScript §21.3.2.15 `Math.expm1(x)`.
+///
+/// Returns *e*^`x` − 1, computed in a way that is accurate even when `x` is
+/// close to zero.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::math::math_expm1;
+///
+/// assert!((math_expm1(0.0) - 0.0).abs() < 1e-15);
+/// assert!(math_expm1(f64::NAN).is_nan());
+/// ```
+pub fn math_expm1(x: f64) -> f64 {
+    x.exp_m1()
+}
+
+// ── Math.log1p ────────────────────────────────────────────────────────────────
+
+/// ECMAScript §21.3.2.23 `Math.log1p(x)`.
+///
+/// Returns the natural logarithm of `1 + x`, computed in a way that is
+/// accurate even when `x` is close to zero.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::math::math_log1p;
+///
+/// assert!((math_log1p(0.0) - 0.0).abs() < 1e-15);
+/// assert_eq!(math_log1p(-1.0), f64::NEG_INFINITY);
+/// assert!(math_log1p(f64::NAN).is_nan());
+/// ```
+pub fn math_log1p(x: f64) -> f64 {
+    x.ln_1p()
+}
+
+// ── Math.sinh / Math.cosh / Math.tanh ─────────────────────────────────────────
+
+/// ECMAScript §21.3.2.31 `Math.sinh(x)`.
+///
+/// Returns the hyperbolic sine of `x`.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::math::math_sinh;
+///
+/// assert!((math_sinh(0.0) - 0.0).abs() < 1e-15);
+/// ```
+pub fn math_sinh(x: f64) -> f64 {
+    x.sinh()
+}
+
+/// ECMAScript §21.3.2.12 `Math.cosh(x)`.
+///
+/// Returns the hyperbolic cosine of `x`.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::math::math_cosh;
+///
+/// assert!((math_cosh(0.0) - 1.0).abs() < 1e-15);
+/// ```
+pub fn math_cosh(x: f64) -> f64 {
+    x.cosh()
+}
+
+/// ECMAScript §21.3.2.34 `Math.tanh(x)`.
+///
+/// Returns the hyperbolic tangent of `x`.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::math::math_tanh;
+///
+/// assert!((math_tanh(0.0) - 0.0).abs() < 1e-15);
+/// ```
+pub fn math_tanh(x: f64) -> f64 {
+    x.tanh()
+}
+
+// ── Math.asinh / Math.acosh / Math.atanh ──────────────────────────────────────
+
+/// ECMAScript §21.3.2.5 `Math.asinh(x)`.
+///
+/// Returns the inverse hyperbolic sine of `x`.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::math::math_asinh;
+///
+/// assert!((math_asinh(0.0) - 0.0).abs() < 1e-15);
+/// ```
+pub fn math_asinh(x: f64) -> f64 {
+    x.asinh()
+}
+
+/// ECMAScript §21.3.2.1 `Math.acosh(x)`.
+///
+/// Returns the inverse hyperbolic cosine of `x`.  Returns `NaN` for
+/// inputs less than 1.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::math::math_acosh;
+///
+/// assert!((math_acosh(1.0) - 0.0).abs() < 1e-15);
+/// assert!(math_acosh(0.5).is_nan());
+/// ```
+pub fn math_acosh(x: f64) -> f64 {
+    x.acosh()
+}
+
+/// ECMAScript §21.3.2.7 `Math.atanh(x)`.
+///
+/// Returns the inverse hyperbolic tangent of `x`.  Returns `NaN` for
+/// inputs with absolute value greater than 1.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::math::math_atanh;
+///
+/// assert!((math_atanh(0.0) - 0.0).abs() < 1e-15);
+/// assert!(math_atanh(2.0).is_nan());
+/// ```
+pub fn math_atanh(x: f64) -> f64 {
+    x.atanh()
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Tests
 // ──────────────────────────────────────────────────────────────────────────────
@@ -664,9 +826,11 @@ mod tests {
 
     #[test]
     fn test_round_negative_half() {
-        // ECMAScript: -0.5 rounds to -0 (i.e. 0), -1.5 rounds to -1.
+        // ECMAScript: -0.5 rounds to -0, -1.5 rounds to -1.
         assert_eq!(math_round(-1.5), -1.0);
-        assert_eq!(math_round(-0.5), 0.0);
+        let r = math_round(-0.5);
+        assert_eq!(r, 0.0);
+        assert!(r.is_sign_negative());
     }
 
     #[test]
@@ -984,5 +1148,152 @@ mod tests {
         // Per ECMAScript, if any value is Infinity, result is Infinity even
         // if there is a NaN.
         assert_eq!(math_hypot(&[f64::INFINITY, f64::NAN]), f64::INFINITY);
+    }
+
+    // ── math_round edge cases ────────────────────────────────────────────────
+
+    #[test]
+    fn test_round_negative_zero() {
+        // Math.round(-0) → -0
+        let r = math_round(-0.0_f64);
+        assert_eq!(r, 0.0);
+        assert!(r.is_sign_negative());
+    }
+
+    #[test]
+    fn test_round_small_negative() {
+        // Math.round(-0.3) → -0
+        let r = math_round(-0.3);
+        assert_eq!(r, 0.0);
+        assert!(r.is_sign_negative());
+    }
+
+    // ── math_max / math_min signed-zero ──────────────────────────────────────
+
+    #[test]
+    fn test_max_negative_zero_positive_zero() {
+        // Math.max(-0, +0) → +0
+        let r = math_max(&[-0.0, 0.0]);
+        assert_eq!(r, 0.0);
+        assert!(r.is_sign_positive());
+    }
+
+    #[test]
+    fn test_min_positive_zero_negative_zero() {
+        // Math.min(+0, -0) → -0
+        let r = math_min(&[0.0, -0.0]);
+        assert_eq!(r, 0.0);
+        assert!(r.is_sign_negative());
+    }
+
+    // ── math_exp ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_exp_zero() {
+        assert_eq!(math_exp(0.0), 1.0);
+    }
+
+    #[test]
+    fn test_exp_one() {
+        assert!((math_exp(1.0) - std::f64::consts::E).abs() < 1e-14);
+    }
+
+    #[test]
+    fn test_exp_nan() {
+        assert!(math_exp(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_exp_infinity() {
+        assert_eq!(math_exp(f64::INFINITY), f64::INFINITY);
+        assert_eq!(math_exp(f64::NEG_INFINITY), 0.0);
+    }
+
+    // ── math_expm1 ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_expm1_zero() {
+        assert_eq!(math_expm1(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_expm1_nan() {
+        assert!(math_expm1(f64::NAN).is_nan());
+    }
+
+    // ── math_log1p ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_log1p_zero() {
+        assert_eq!(math_log1p(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_log1p_minus_one() {
+        assert_eq!(math_log1p(-1.0), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_log1p_nan() {
+        assert!(math_log1p(f64::NAN).is_nan());
+    }
+
+    // ── math_sinh / math_cosh / math_tanh ────────────────────────────────────
+
+    #[test]
+    fn test_sinh_zero() {
+        assert_eq!(math_sinh(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_cosh_zero() {
+        assert_eq!(math_cosh(0.0), 1.0);
+    }
+
+    #[test]
+    fn test_tanh_zero() {
+        assert_eq!(math_tanh(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_sinh_nan() {
+        assert!(math_sinh(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_cosh_nan() {
+        assert!(math_cosh(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_tanh_nan() {
+        assert!(math_tanh(f64::NAN).is_nan());
+    }
+
+    // ── math_asinh / math_acosh / math_atanh ─────────────────────────────────
+
+    #[test]
+    fn test_asinh_zero() {
+        assert_eq!(math_asinh(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_acosh_one() {
+        assert!((math_acosh(1.0) - 0.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_acosh_less_than_one() {
+        assert!(math_acosh(0.5).is_nan());
+    }
+
+    #[test]
+    fn test_atanh_zero() {
+        assert_eq!(math_atanh(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_atanh_out_of_range() {
+        assert!(math_atanh(2.0).is_nan());
     }
 }

--- a/crates/stator_core/src/builtins/number.rs
+++ b/crates/stator_core/src/builtins/number.rs
@@ -27,8 +27,9 @@ pub const NUMBER_MIN_SAFE_INTEGER: f64 = -9_007_199_254_740_991.0_f64;
 /// The largest finite floating-point number representable in JavaScript.
 pub const NUMBER_MAX_VALUE: f64 = f64::MAX;
 
-/// The smallest positive floating-point number representable in JavaScript.
-pub const NUMBER_MIN_VALUE: f64 = f64::MIN_POSITIVE;
+/// The smallest positive floating-point number representable in JavaScript
+/// (the smallest subnormal, `5e-324`).
+pub const NUMBER_MIN_VALUE: f64 = 5e-324;
 
 /// The difference between 1.0 and the next representable `f64` value.
 pub const NUMBER_EPSILON: f64 = f64::EPSILON;
@@ -197,8 +198,9 @@ pub fn number_parse_int(string: &str, radix: u32) -> f64 {
 
 /// ECMAScript §21.1.2.7 `Number.parseFloat(string)`.
 ///
-/// Parses a string as an IEEE 754 double.  Returns `NaN` if the string does
-/// not represent a valid number.
+/// Parses the longest valid numeric prefix of `string` as an IEEE 754 double.
+/// Returns `NaN` if no valid prefix exists.  Recognises `"Infinity"` and
+/// `"-Infinity"` per spec.
 ///
 /// # Examples
 ///
@@ -207,14 +209,79 @@ pub fn number_parse_int(string: &str, radix: u32) -> f64 {
 ///
 /// assert_eq!(number_parse_float("3.14"), 3.14);
 /// assert_eq!(number_parse_float("  -2.5  "), -2.5);
+/// assert_eq!(number_parse_float("3.14abc"), 3.14);
+/// assert_eq!(number_parse_float("Infinity"), f64::INFINITY);
 /// assert!(number_parse_float("abc").is_nan());
 /// ```
 pub fn number_parse_float(string: &str) -> f64 {
-    let s = string.trim();
+    let s = string.trim_start();
     if s.is_empty() {
         return f64::NAN;
     }
-    s.parse::<f64>().unwrap_or(f64::NAN)
+
+    // Handle optional sign + "Infinity".
+    let (sign, rest) = match s.as_bytes().first() {
+        Some(b'+') => (1.0_f64, &s[1..]),
+        Some(b'-') => (-1.0_f64, &s[1..]),
+        _ => (1.0_f64, s),
+    };
+    if rest.starts_with("Infinity") {
+        return sign * f64::INFINITY;
+    }
+
+    // Find the longest prefix that forms a valid StrDecimalLiteral.
+    let end = float_prefix_end(s);
+    if end == 0 {
+        return f64::NAN;
+    }
+    s[..end].parse::<f64>().unwrap_or(f64::NAN)
+}
+
+/// Returns the byte-length of the longest valid numeric prefix in `s`.
+fn float_prefix_end(s: &str) -> usize {
+    let b = s.as_bytes();
+    let mut i = 0;
+
+    // Optional sign.
+    if i < b.len() && (b[i] == b'+' || b[i] == b'-') {
+        i += 1;
+    }
+
+    // Integer part.
+    let mut has_digits = false;
+    while i < b.len() && b[i].is_ascii_digit() {
+        i += 1;
+        has_digits = true;
+    }
+
+    // Fractional part.
+    if i < b.len() && b[i] == b'.' {
+        i += 1;
+        while i < b.len() && b[i].is_ascii_digit() {
+            i += 1;
+            has_digits = true;
+        }
+    }
+
+    if !has_digits {
+        return 0;
+    }
+    let mut end = i;
+
+    // Exponent part.
+    if i < b.len() && (b[i] == b'e' || b[i] == b'E') {
+        let mut j = i + 1;
+        if j < b.len() && (b[j] == b'+' || b[j] == b'-') {
+            j += 1;
+        }
+        if j < b.len() && b[j].is_ascii_digit() {
+            while j < b.len() && b[j].is_ascii_digit() {
+                j += 1;
+            }
+            end = j;
+        }
+    }
+    end
 }
 
 // ── Number.prototype.toFixed ──────────────────────────────────────────────────
@@ -252,11 +319,9 @@ pub fn number_to_fixed(value: f64, digits: u32) -> StatorResult<String> {
             "-Infinity".to_string()
         });
     }
-    // Values >= 1e21 are formatted in exponential notation by ECMAScript.
+    // Per spec §21.1.3.3: values >= 1e21 return ToString(value).
     if value.abs() >= 1e21 {
-        return Err(StatorError::RangeError(
-            "toFixed() value is too large".to_string(),
-        ));
+        return Ok(format!("{value}"));
     }
     Ok(format!("{:.prec$}", value, prec = digits as usize))
 }
@@ -644,6 +709,20 @@ mod tests {
         assert!(number_parse_float("").is_nan());
     }
 
+    #[test]
+    fn test_parse_float_prefix() {
+        // Parses the longest valid numeric prefix.
+        assert_eq!(number_parse_float("3.14abc"), 3.14);
+        assert_eq!(number_parse_float("123xyz"), 123.0);
+    }
+
+    #[test]
+    fn test_parse_float_infinity() {
+        assert_eq!(number_parse_float("Infinity"), f64::INFINITY);
+        assert_eq!(number_parse_float("-Infinity"), f64::NEG_INFINITY);
+        assert_eq!(number_parse_float("+Infinity"), f64::INFINITY);
+    }
+
     // ── number_to_fixed ──────────────────────────────────────────────────────
 
     #[test]
@@ -670,10 +749,9 @@ mod tests {
 
     #[test]
     fn test_to_fixed_large_value() {
-        assert!(matches!(
-            number_to_fixed(1e22, 2),
-            Err(StatorError::RangeError(_))
-        ));
+        // Per spec, values >= 1e21 return ToString(value), not a RangeError.
+        let s = number_to_fixed(1e22, 2).unwrap();
+        assert!(!s.is_empty());
     }
 
     // ── number_to_precision ──────────────────────────────────────────────────
@@ -820,5 +898,13 @@ mod tests {
     fn test_ieee754_max_safe_integer_plus_one_is_not_safe() {
         // 2^53 is representable but not safe because 2^53 + 1 == 2^53 in f64.
         assert!(!number_is_safe_integer(NUMBER_MAX_SAFE_INTEGER + 1.0));
+    }
+
+    #[test]
+    fn test_min_value_is_subnormal() {
+        // NUMBER_MIN_VALUE must be the smallest positive subnormal (5e-324).
+        assert!(NUMBER_MIN_VALUE > 0.0);
+        assert!(NUMBER_MIN_VALUE < f64::MIN_POSITIVE);
+        assert_eq!(NUMBER_MIN_VALUE, 5e-324);
     }
 }


### PR DESCRIPTION
Closes #290

## Changes

### Math builtins (math.rs)
- **9 new methods**: \xp\, \xpm1\, \log1p\, \sinh\, \cosh\, \	anh\, \sinh\, \cosh\, \tanh\ — completing all 35 ES2025 §21.3 methods
- **Fix \Math.round\**: Returns \-0\ for values in \[-0.5, -0]\ per spec §21.3.2.28
- **Fix \Math.max/min\**: Correct signed-zero handling (\+0 > -0\ for max, \-0 < +0\ for min)

### Number builtins (\
umber.rs\)
- **Fix \Number.MIN_VALUE\**: Use smallest subnormal \5e-324\ (was incorrectly \64::MIN_POSITIVE\)
- **Fix \Number.parseFloat\**: Parse longest valid prefix (e.g. \'3.14abc' → 3.14\), handle \Infinity\/\-Infinity\
- **Fix \Number.toFixed\**: Values ≥ 1e21 return \	oString()\ instead of throwing RangeError per spec §21.1.3.3

### Wiring (\install_globals.rs\)
- Wire all 9 new Math methods
- Add \Number.isSafeInteger\
- Fix \Number.MIN_VALUE\ constant

### Tests
- 25+ new unit tests covering all new methods and edge cases
- Updated existing tests for spec-correct behavior