### PR TITLE
feat: global functions + iterator helpers

### DIFF
--- a/crates/stator_core/src/builtins/install_globals.rs
+++ b/crates/stator_core/src/builtins/install_globals.rs
@@ -27,6 +27,11 @@ use crate::builtins::global::{
     global_encode_uri_component, global_is_finite, global_is_nan, global_parse_float,
     global_parse_int,
 };
+use crate::builtins::iterator::{
+    iterator_drop, iterator_every, iterator_filter, iterator_find, iterator_flat_map,
+    iterator_for_each, iterator_from, iterator_map, iterator_reduce, iterator_some, iterator_take,
+    iterator_to_array,
+};
 use crate::builtins::math::{
     MATH_E, MATH_LN2, MATH_LN10, MATH_LOG2E, MATH_LOG10E, MATH_PI, MATH_SQRT1_2, MATH_SQRT2,
     math_abs, math_acos, math_asin, math_atan, math_atan2, math_cbrt, math_ceil, math_clz32,
@@ -862,6 +867,135 @@ fn make_symbol() -> JsValue {
 
     JsValue::PlainObject(Rc::new(RefCell::new(props)))
 }
+
+// ── Iterator (ES2025 §27.1.4) ────────────────────────────────────────────────
+
+/// Build the `Iterator` constructor/namespace object with prototype helpers.
+fn make_iterator() -> JsValue {
+    let mut props: HashMap<String, JsValue> = HashMap::new();
+
+    // ── Static method: Iterator.from ──────────────────────────────────────
+    props.insert(
+        "from".into(),
+        native(|args| {
+            let iterable = args.first().unwrap_or(&JsValue::Undefined);
+            iterator_from(iterable)
+        }),
+    );
+
+    // ── Prototype (instance) methods ─────────────────────────────────────
+    //
+    // In a full engine these would live on Iterator.prototype.  Here we
+    // attach them as own properties so that `Iterator.prototype.map(…)` is
+    // accessible as `Iterator.map(iter, mapper)` for direct testing and for
+    // the bytecode to call via property lookup.
+    let mut proto: HashMap<String, JsValue> = HashMap::new();
+
+    proto.insert(
+        "map".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            let mapper = args.get(1).unwrap_or(&JsValue::Undefined);
+            iterator_map(iter, mapper)
+        }),
+    );
+    proto.insert(
+        "filter".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            let predicate = args.get(1).unwrap_or(&JsValue::Undefined);
+            iterator_filter(iter, predicate)
+        }),
+    );
+    proto.insert(
+        "take".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            let limit = args
+                .get(1)
+                .unwrap_or(&JsValue::Undefined)
+                .to_number()
+                .unwrap_or(0.0);
+            iterator_take(iter, limit.max(0.0) as usize)
+        }),
+    );
+    proto.insert(
+        "drop".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            let count = args
+                .get(1)
+                .unwrap_or(&JsValue::Undefined)
+                .to_number()
+                .unwrap_or(0.0);
+            iterator_drop(iter, count.max(0.0) as usize)
+        }),
+    );
+    proto.insert(
+        "flatMap".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            let mapper = args.get(1).unwrap_or(&JsValue::Undefined);
+            iterator_flat_map(iter, mapper)
+        }),
+    );
+    proto.insert(
+        "reduce".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            let reducer = args.get(1).unwrap_or(&JsValue::Undefined);
+            let initial = args.get(2).cloned();
+            iterator_reduce(iter, reducer, initial)
+        }),
+    );
+    proto.insert(
+        "toArray".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            iterator_to_array(iter)
+        }),
+    );
+    proto.insert(
+        "forEach".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            let callback = args.get(1).unwrap_or(&JsValue::Undefined);
+            iterator_for_each(iter, callback)
+        }),
+    );
+    proto.insert(
+        "some".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            let predicate = args.get(1).unwrap_or(&JsValue::Undefined);
+            iterator_some(iter, predicate)
+        }),
+    );
+    proto.insert(
+        "every".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            let predicate = args.get(1).unwrap_or(&JsValue::Undefined);
+            iterator_every(iter, predicate)
+        }),
+    );
+    proto.insert(
+        "find".into(),
+        native(|args| {
+            let iter = args.first().unwrap_or(&JsValue::Undefined);
+            let predicate = args.get(1).unwrap_or(&JsValue::Undefined);
+            iterator_find(iter, predicate)
+        }),
+    );
+
+    props.insert(
+        "prototype".into(),
+        JsValue::PlainObject(Rc::new(RefCell::new(proto))),
+    );
+
+    JsValue::PlainObject(Rc::new(RefCell::new(props)))
+}
+
 // ── install_globals ──────────────────────────────────────────────────────────
 
 /// Pre-populate `globals` with all ECMAScript built-in names.
@@ -881,6 +1015,7 @@ pub fn install_globals(globals: &mut HashMap<String, JsValue>) {
     globals.insert("Object".into(), make_object());
     globals.insert("Array".into(), make_array());
     globals.insert("Symbol".into(), make_symbol());
+    globals.insert("Iterator".into(), make_iterator());
 
     // ── Error constructors ────────────────────────────────────────────────
     install_error_constructors(globals);
@@ -976,6 +1111,12 @@ pub fn install_globals(globals: &mut HashMap<String, JsValue>) {
             Ok(JsValue::String(global_decode_uri_component(&s)?))
         }),
     );
+
+    // ── globalThis (ECMAScript §19.1) ───────────────────────────────────
+    // `globalThis` is a self-referential property of the global object.
+    // We represent the global object as a PlainObject snapshot.
+    let global_this = JsValue::PlainObject(Rc::new(RefCell::new(globals.clone())));
+    globals.insert("globalThis".into(), global_this);
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -1003,6 +1144,8 @@ mod tests {
         assert!(globals.contains_key("NaN"));
         assert!(globals.contains_key("Infinity"));
         assert!(globals.contains_key("Symbol"));
+        assert!(globals.contains_key("Iterator"));
+        assert!(globals.contains_key("globalThis"));
     }
 
     /// Verify that the `Math` object has the expected properties.
@@ -1711,6 +1854,109 @@ mod tests {
             assert!(map.contains_key("entries"));
         } else {
             panic!("Object should be a PlainObject");
+        }
+    }
+
+    // ── Iterator tests ──────────────────────────────────────────────────────
+
+    /// `Iterator` is available as a global PlainObject.
+    #[test]
+    fn test_iterator_global_exists() {
+        let mut globals = HashMap::new();
+        install_globals(&mut globals);
+        assert!(matches!(
+            globals.get("Iterator"),
+            Some(JsValue::PlainObject(_))
+        ));
+    }
+
+    /// `Iterator` has a `from` static method and a `prototype` with helpers.
+    #[test]
+    fn test_iterator_object_properties() {
+        let mut globals = HashMap::new();
+        install_globals(&mut globals);
+        let iter_obj = globals.get("Iterator").unwrap();
+        if let JsValue::PlainObject(map) = iter_obj {
+            let map = map.borrow();
+            assert!(matches!(map.get("from"), Some(JsValue::NativeFunction(_))));
+            assert!(matches!(
+                map.get("prototype"),
+                Some(JsValue::PlainObject(_))
+            ));
+            if let Some(JsValue::PlainObject(proto)) = map.get("prototype") {
+                let proto = proto.borrow();
+                assert!(matches!(proto.get("map"), Some(JsValue::NativeFunction(_))));
+                assert!(matches!(
+                    proto.get("filter"),
+                    Some(JsValue::NativeFunction(_))
+                ));
+                assert!(matches!(
+                    proto.get("take"),
+                    Some(JsValue::NativeFunction(_))
+                ));
+                assert!(matches!(
+                    proto.get("drop"),
+                    Some(JsValue::NativeFunction(_))
+                ));
+                assert!(matches!(
+                    proto.get("flatMap"),
+                    Some(JsValue::NativeFunction(_))
+                ));
+                assert!(matches!(
+                    proto.get("reduce"),
+                    Some(JsValue::NativeFunction(_))
+                ));
+                assert!(matches!(
+                    proto.get("toArray"),
+                    Some(JsValue::NativeFunction(_))
+                ));
+                assert!(matches!(
+                    proto.get("forEach"),
+                    Some(JsValue::NativeFunction(_))
+                ));
+                assert!(matches!(
+                    proto.get("some"),
+                    Some(JsValue::NativeFunction(_))
+                ));
+                assert!(matches!(
+                    proto.get("every"),
+                    Some(JsValue::NativeFunction(_))
+                ));
+                assert!(matches!(
+                    proto.get("find"),
+                    Some(JsValue::NativeFunction(_))
+                ));
+            }
+        } else {
+            panic!("Iterator should be a PlainObject");
+        }
+    }
+
+    // ── globalThis tests ────────────────────────────────────────────────────
+
+    /// `globalThis` is a PlainObject containing the global scope keys.
+    #[test]
+    fn test_global_this_exists() {
+        let mut globals = HashMap::new();
+        install_globals(&mut globals);
+        assert!(matches!(
+            globals.get("globalThis"),
+            Some(JsValue::PlainObject(_))
+        ));
+    }
+
+    /// `globalThis` contains the same keys as the global scope.
+    #[test]
+    fn test_global_this_has_keys() {
+        let mut globals = HashMap::new();
+        install_globals(&mut globals);
+        if let Some(JsValue::PlainObject(gt)) = globals.get("globalThis") {
+            let gt = gt.borrow();
+            assert!(gt.contains_key("Math"));
+            assert!(gt.contains_key("parseInt"));
+            assert!(gt.contains_key("Iterator"));
+        } else {
+            panic!("globalThis should be a PlainObject");
         }
     }
 }

--- a/crates/stator_core/src/builtins/iterator.rs
+++ b/crates/stator_core/src/builtins/iterator.rs
@@ -221,6 +221,330 @@ pub fn iterator_to_vec(iter: &JsValue) -> StatorResult<Vec<JsValue>> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Private: call a JsValue callback
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Invoke `func` with the given arguments.
+///
+/// Returns [`StatorError::TypeError`] if `func` is not a callable
+/// [`JsValue::NativeFunction`].
+fn call_fn(func: &JsValue, args: Vec<JsValue>) -> StatorResult<JsValue> {
+    match func {
+        JsValue::NativeFunction(f) => f(args),
+        _ => Err(StatorError::TypeError(
+            "iterator helper: callback is not a function".into(),
+        )),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Iterator Helpers — ES2025 (§27.1.4)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// ES2025 `Iterator.prototype.map(mapper)`.
+///
+/// Returns a new iterator that yields the result of applying `mapper` to each
+/// element of `iter`.
+///
+/// # Errors
+///
+/// Propagates any error from the source iterator or the mapper callback.
+pub fn iterator_map(iter: &JsValue, mapper: &JsValue) -> StatorResult<JsValue> {
+    let mut out = Vec::new();
+    let mut index = 0i64;
+    loop {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            break;
+        }
+        let mapped = call_fn(mapper, vec![rec.value, JsValue::HeapNumber(index as f64)])?;
+        out.push(mapped);
+        index += 1;
+    }
+    Ok(make_array_iterator(out))
+}
+
+/// ES2025 `Iterator.prototype.filter(predicate)`.
+///
+/// Returns a new iterator that yields only the elements of `iter` for which
+/// `predicate` returns a truthy value.
+///
+/// # Errors
+///
+/// Propagates any error from the source iterator or the predicate callback.
+pub fn iterator_filter(iter: &JsValue, predicate: &JsValue) -> StatorResult<JsValue> {
+    let mut out = Vec::new();
+    let mut index = 0i64;
+    loop {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            break;
+        }
+        let result = call_fn(
+            predicate,
+            vec![rec.value.clone(), JsValue::HeapNumber(index as f64)],
+        )?;
+        if result.to_boolean() {
+            out.push(rec.value);
+        }
+        index += 1;
+    }
+    Ok(make_array_iterator(out))
+}
+
+/// ES2025 `Iterator.prototype.take(limit)`.
+///
+/// Returns a new iterator that yields at most `limit` elements from `iter`.
+///
+/// # Errors
+///
+/// Propagates any error from the source iterator.
+pub fn iterator_take(iter: &JsValue, limit: usize) -> StatorResult<JsValue> {
+    let mut out = Vec::new();
+    for _ in 0..limit {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            break;
+        }
+        out.push(rec.value);
+    }
+    Ok(make_array_iterator(out))
+}
+
+/// ES2025 `Iterator.prototype.drop(count)`.
+///
+/// Returns a new iterator that skips the first `count` elements of `iter`,
+/// then yields the rest.
+///
+/// # Errors
+///
+/// Propagates any error from the source iterator.
+pub fn iterator_drop(iter: &JsValue, count: usize) -> StatorResult<JsValue> {
+    // Skip the first `count` items.
+    for _ in 0..count {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            return Ok(make_array_iterator(vec![]));
+        }
+    }
+    // Collect the rest.
+    let mut out = Vec::new();
+    loop {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            break;
+        }
+        out.push(rec.value);
+    }
+    Ok(make_array_iterator(out))
+}
+
+/// ES2025 `Iterator.prototype.flatMap(mapper)`.
+///
+/// Returns a new iterator that yields the concatenation of iterators (or
+/// single values) produced by applying `mapper` to each element of `iter`.
+/// If the mapper returns an iterator or array, its elements are flattened
+/// one level deep.
+///
+/// # Errors
+///
+/// Propagates any error from the source iterator or the mapper callback.
+pub fn iterator_flat_map(iter: &JsValue, mapper: &JsValue) -> StatorResult<JsValue> {
+    let mut out = Vec::new();
+    let mut index = 0i64;
+    loop {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            break;
+        }
+        let mapped = call_fn(mapper, vec![rec.value, JsValue::HeapNumber(index as f64)])?;
+        match &mapped {
+            JsValue::Iterator(_) | JsValue::Generator(_) => {
+                let inner = iterator_to_vec(&mapped)?;
+                out.extend(inner);
+            }
+            JsValue::Array(arr) => {
+                out.extend(arr.iter().cloned());
+            }
+            _ => {
+                out.push(mapped);
+            }
+        }
+        index += 1;
+    }
+    Ok(make_array_iterator(out))
+}
+
+/// ES2025 `Iterator.prototype.reduce(reducer, initialValue)`.
+///
+/// Reduces the elements of `iter` to a single value by repeatedly calling
+/// `reducer(accumulator, currentValue)`. If `initial` is `None`, the first
+/// element is used as the initial accumulator.
+///
+/// # Errors
+///
+/// - [`StatorError::TypeError`] if `iter` is empty and no `initial` value is
+///   provided.
+/// - Propagates any error from the source iterator or the reducer callback.
+pub fn iterator_reduce(
+    iter: &JsValue,
+    reducer: &JsValue,
+    initial: Option<JsValue>,
+) -> StatorResult<JsValue> {
+    let mut acc = match initial {
+        Some(v) => v,
+        None => {
+            let rec = iterator_next(iter)?;
+            if rec.done {
+                return Err(StatorError::TypeError(
+                    "Reduce of empty iterator with no initial value".into(),
+                ));
+            }
+            rec.value
+        }
+    };
+    loop {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            break;
+        }
+        acc = call_fn(reducer, vec![acc, rec.value])?;
+    }
+    Ok(acc)
+}
+
+/// ES2025 `Iterator.prototype.toArray()`.
+///
+/// Eagerly collects all remaining elements of `iter` into a
+/// [`JsValue::Array`].
+///
+/// # Errors
+///
+/// Propagates any error from the source iterator.
+pub fn iterator_to_array(iter: &JsValue) -> StatorResult<JsValue> {
+    let items = iterator_to_vec(iter)?;
+    Ok(JsValue::Array(Rc::new(items)))
+}
+
+/// ES2025 `Iterator.prototype.forEach(callback)`.
+///
+/// Calls `callback` for each element of `iter` and returns `undefined`.
+///
+/// # Errors
+///
+/// Propagates any error from the source iterator or the callback.
+pub fn iterator_for_each(iter: &JsValue, callback: &JsValue) -> StatorResult<JsValue> {
+    let mut index = 0i64;
+    loop {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            break;
+        }
+        call_fn(callback, vec![rec.value, JsValue::HeapNumber(index as f64)])?;
+        index += 1;
+    }
+    Ok(JsValue::Undefined)
+}
+
+/// ES2025 `Iterator.prototype.some(predicate)`.
+///
+/// Returns `true` if `predicate` returns a truthy value for any element of
+/// `iter`, otherwise `false`.
+///
+/// # Errors
+///
+/// Propagates any error from the source iterator or the predicate callback.
+pub fn iterator_some(iter: &JsValue, predicate: &JsValue) -> StatorResult<JsValue> {
+    let mut index = 0i64;
+    loop {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            return Ok(JsValue::Boolean(false));
+        }
+        let result = call_fn(
+            predicate,
+            vec![rec.value, JsValue::HeapNumber(index as f64)],
+        )?;
+        if result.to_boolean() {
+            return Ok(JsValue::Boolean(true));
+        }
+        index += 1;
+    }
+}
+
+/// ES2025 `Iterator.prototype.every(predicate)`.
+///
+/// Returns `true` if `predicate` returns a truthy value for every element of
+/// `iter`, otherwise `false`.
+///
+/// # Errors
+///
+/// Propagates any error from the source iterator or the predicate callback.
+pub fn iterator_every(iter: &JsValue, predicate: &JsValue) -> StatorResult<JsValue> {
+    let mut index = 0i64;
+    loop {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            return Ok(JsValue::Boolean(true));
+        }
+        let result = call_fn(
+            predicate,
+            vec![rec.value, JsValue::HeapNumber(index as f64)],
+        )?;
+        if !result.to_boolean() {
+            return Ok(JsValue::Boolean(false));
+        }
+        index += 1;
+    }
+}
+
+/// ES2025 `Iterator.prototype.find(predicate)`.
+///
+/// Returns the first element of `iter` for which `predicate` returns a truthy
+/// value, or `undefined` if none match.
+///
+/// # Errors
+///
+/// Propagates any error from the source iterator or the predicate callback.
+pub fn iterator_find(iter: &JsValue, predicate: &JsValue) -> StatorResult<JsValue> {
+    let mut index = 0i64;
+    loop {
+        let rec = iterator_next(iter)?;
+        if rec.done {
+            return Ok(JsValue::Undefined);
+        }
+        let result = call_fn(
+            predicate,
+            vec![rec.value.clone(), JsValue::HeapNumber(index as f64)],
+        )?;
+        if result.to_boolean() {
+            return Ok(rec.value);
+        }
+        index += 1;
+    }
+}
+
+/// ES2025 `Iterator.from(iterable)`.
+///
+/// If `iterable` is already an iterator, returns it unchanged. If it is an
+/// array, wraps it in an array iterator. Otherwise returns a
+/// [`StatorError::TypeError`].
+///
+/// # Errors
+///
+/// Returns [`StatorError::TypeError`] if `iterable` is not an iterator or array.
+pub fn iterator_from(iterable: &JsValue) -> StatorResult<JsValue> {
+    match iterable {
+        JsValue::Iterator(_) | JsValue::Generator(_) => Ok(iterable.clone()),
+        JsValue::Array(arr) => Ok(make_array_iterator(arr.as_ref().clone())),
+        JsValue::String(s) => Ok(make_string_iterator(s)),
+        _ => Err(StatorError::TypeError(format!(
+            "Iterator.from: value is not iterable (got {iterable:?})"
+        ))),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -466,5 +790,357 @@ mod tests {
             collected,
             vec![JsValue::Smi(100), JsValue::Smi(200), JsValue::Smi(300)]
         );
+    }
+
+    // ── Helper: make a native function for testing ────────────────────────────
+
+    fn make_native_fn(f: impl Fn(Vec<JsValue>) -> StatorResult<JsValue> + 'static) -> JsValue {
+        JsValue::NativeFunction(Rc::new(f))
+    }
+
+    // ── iterator_map ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_map_doubles_values() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(2), JsValue::Smi(3)]);
+        let mapper = make_native_fn(|args| {
+            let n = args[0].to_number()?;
+            Ok(JsValue::Smi((n * 2.0) as i32))
+        });
+        let result = iterator_map(&iter, &mapper).unwrap();
+        let items = iterator_to_vec(&result).unwrap();
+        assert_eq!(
+            items,
+            vec![JsValue::Smi(2), JsValue::Smi(4), JsValue::Smi(6)]
+        );
+    }
+
+    #[test]
+    fn test_iterator_map_empty() {
+        let iter = make_array_iterator(vec![]);
+        let mapper = make_native_fn(|args| Ok(args[0].clone()));
+        let result = iterator_map(&iter, &mapper).unwrap();
+        assert!(iterator_to_vec(&result).unwrap().is_empty());
+    }
+
+    // ── iterator_filter ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_filter_even() {
+        let iter = make_array_iterator(vec![
+            JsValue::Smi(1),
+            JsValue::Smi(2),
+            JsValue::Smi(3),
+            JsValue::Smi(4),
+        ]);
+        let pred = make_native_fn(|args| {
+            let n = args[0].to_number()?;
+            Ok(JsValue::Boolean(n as i64 % 2 == 0))
+        });
+        let result = iterator_filter(&iter, &pred).unwrap();
+        let items = iterator_to_vec(&result).unwrap();
+        assert_eq!(items, vec![JsValue::Smi(2), JsValue::Smi(4)]);
+    }
+
+    #[test]
+    fn test_iterator_filter_none_match() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(3)]);
+        let pred = make_native_fn(|_| Ok(JsValue::Boolean(false)));
+        let result = iterator_filter(&iter, &pred).unwrap();
+        assert!(iterator_to_vec(&result).unwrap().is_empty());
+    }
+
+    // ── iterator_take ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_take() {
+        let iter = make_array_iterator(vec![
+            JsValue::Smi(1),
+            JsValue::Smi(2),
+            JsValue::Smi(3),
+            JsValue::Smi(4),
+        ]);
+        let result = iterator_take(&iter, 2).unwrap();
+        let items = iterator_to_vec(&result).unwrap();
+        assert_eq!(items, vec![JsValue::Smi(1), JsValue::Smi(2)]);
+    }
+
+    #[test]
+    fn test_iterator_take_more_than_available() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1)]);
+        let result = iterator_take(&iter, 10).unwrap();
+        let items = iterator_to_vec(&result).unwrap();
+        assert_eq!(items, vec![JsValue::Smi(1)]);
+    }
+
+    #[test]
+    fn test_iterator_take_zero() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(2)]);
+        let result = iterator_take(&iter, 0).unwrap();
+        assert!(iterator_to_vec(&result).unwrap().is_empty());
+    }
+
+    // ── iterator_drop ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_drop() {
+        let iter = make_array_iterator(vec![
+            JsValue::Smi(1),
+            JsValue::Smi(2),
+            JsValue::Smi(3),
+            JsValue::Smi(4),
+        ]);
+        let result = iterator_drop(&iter, 2).unwrap();
+        let items = iterator_to_vec(&result).unwrap();
+        assert_eq!(items, vec![JsValue::Smi(3), JsValue::Smi(4)]);
+    }
+
+    #[test]
+    fn test_iterator_drop_all() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1)]);
+        let result = iterator_drop(&iter, 5).unwrap();
+        assert!(iterator_to_vec(&result).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_iterator_drop_zero() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(2)]);
+        let result = iterator_drop(&iter, 0).unwrap();
+        let items = iterator_to_vec(&result).unwrap();
+        assert_eq!(items, vec![JsValue::Smi(1), JsValue::Smi(2)]);
+    }
+
+    // ── iterator_flat_map ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_flat_map_with_arrays() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(2)]);
+        let mapper = make_native_fn(|args| {
+            let n = args[0].to_number()? as i32;
+            Ok(JsValue::Array(Rc::new(vec![
+                JsValue::Smi(n),
+                JsValue::Smi(n * 10),
+            ])))
+        });
+        let result = iterator_flat_map(&iter, &mapper).unwrap();
+        let items = iterator_to_vec(&result).unwrap();
+        assert_eq!(
+            items,
+            vec![
+                JsValue::Smi(1),
+                JsValue::Smi(10),
+                JsValue::Smi(2),
+                JsValue::Smi(20)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_iterator_flat_map_with_scalars() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(2)]);
+        let mapper = make_native_fn(|args| Ok(args[0].clone()));
+        let result = iterator_flat_map(&iter, &mapper).unwrap();
+        let items = iterator_to_vec(&result).unwrap();
+        assert_eq!(items, vec![JsValue::Smi(1), JsValue::Smi(2)]);
+    }
+
+    // ── iterator_reduce ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_reduce_sum() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(2), JsValue::Smi(3)]);
+        let reducer = make_native_fn(|args| {
+            let a = args[0].to_number()?;
+            let b = args[1].to_number()?;
+            Ok(JsValue::Smi((a + b) as i32))
+        });
+        let result = iterator_reduce(&iter, &reducer, Some(JsValue::Smi(0))).unwrap();
+        assert_eq!(result, JsValue::Smi(6));
+    }
+
+    #[test]
+    fn test_iterator_reduce_no_initial() {
+        let iter = make_array_iterator(vec![JsValue::Smi(10), JsValue::Smi(20)]);
+        let reducer = make_native_fn(|args| {
+            let a = args[0].to_number()?;
+            let b = args[1].to_number()?;
+            Ok(JsValue::Smi((a + b) as i32))
+        });
+        let result = iterator_reduce(&iter, &reducer, None).unwrap();
+        assert_eq!(result, JsValue::Smi(30));
+    }
+
+    #[test]
+    fn test_iterator_reduce_empty_no_initial_errors() {
+        let iter = make_array_iterator(vec![]);
+        let reducer = make_native_fn(|_| Ok(JsValue::Undefined));
+        let err = iterator_reduce(&iter, &reducer, None).unwrap_err();
+        assert!(matches!(err, StatorError::TypeError(_)));
+    }
+
+    // ── iterator_to_array ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_to_array_returns_js_array() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(2)]);
+        let result = iterator_to_array(&iter).unwrap();
+        assert_eq!(
+            result,
+            JsValue::Array(Rc::new(vec![JsValue::Smi(1), JsValue::Smi(2)]))
+        );
+    }
+
+    #[test]
+    fn test_iterator_to_array_empty() {
+        let iter = make_array_iterator(vec![]);
+        let result = iterator_to_array(&iter).unwrap();
+        assert_eq!(result, JsValue::Array(Rc::new(vec![])));
+    }
+
+    // ── iterator_for_each ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_for_each_calls_callback() {
+        use std::cell::Cell;
+        let count = Rc::new(Cell::new(0i32));
+        let count_clone = count.clone();
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(2), JsValue::Smi(3)]);
+        let callback = make_native_fn(move |_| {
+            count_clone.set(count_clone.get() + 1);
+            Ok(JsValue::Undefined)
+        });
+        let result = iterator_for_each(&iter, &callback).unwrap();
+        assert_eq!(result, JsValue::Undefined);
+        assert_eq!(count.get(), 3);
+    }
+
+    // ── iterator_some ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_some_found() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(2), JsValue::Smi(3)]);
+        let pred = make_native_fn(|args| {
+            let n = args[0].to_number()?;
+            Ok(JsValue::Boolean(n == 2.0))
+        });
+        assert_eq!(iterator_some(&iter, &pred).unwrap(), JsValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_iterator_some_not_found() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(3)]);
+        let pred = make_native_fn(|args| {
+            let n = args[0].to_number()?;
+            Ok(JsValue::Boolean(n == 2.0))
+        });
+        assert_eq!(
+            iterator_some(&iter, &pred).unwrap(),
+            JsValue::Boolean(false)
+        );
+    }
+
+    #[test]
+    fn test_iterator_some_empty() {
+        let iter = make_array_iterator(vec![]);
+        let pred = make_native_fn(|_| Ok(JsValue::Boolean(true)));
+        assert_eq!(
+            iterator_some(&iter, &pred).unwrap(),
+            JsValue::Boolean(false)
+        );
+    }
+
+    // ── iterator_every ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_every_all_pass() {
+        let iter = make_array_iterator(vec![JsValue::Smi(2), JsValue::Smi(4), JsValue::Smi(6)]);
+        let pred = make_native_fn(|args| {
+            let n = args[0].to_number()?;
+            Ok(JsValue::Boolean(n as i64 % 2 == 0))
+        });
+        assert_eq!(
+            iterator_every(&iter, &pred).unwrap(),
+            JsValue::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn test_iterator_every_one_fails() {
+        let iter = make_array_iterator(vec![JsValue::Smi(2), JsValue::Smi(3), JsValue::Smi(4)]);
+        let pred = make_native_fn(|args| {
+            let n = args[0].to_number()?;
+            Ok(JsValue::Boolean(n as i64 % 2 == 0))
+        });
+        assert_eq!(
+            iterator_every(&iter, &pred).unwrap(),
+            JsValue::Boolean(false)
+        );
+    }
+
+    #[test]
+    fn test_iterator_every_empty() {
+        let iter = make_array_iterator(vec![]);
+        let pred = make_native_fn(|_| Ok(JsValue::Boolean(false)));
+        assert_eq!(
+            iterator_every(&iter, &pred).unwrap(),
+            JsValue::Boolean(true)
+        );
+    }
+
+    // ── iterator_find ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_find_found() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(2), JsValue::Smi(3)]);
+        let pred = make_native_fn(|args| {
+            let n = args[0].to_number()?;
+            Ok(JsValue::Boolean(n == 2.0))
+        });
+        assert_eq!(iterator_find(&iter, &pred).unwrap(), JsValue::Smi(2));
+    }
+
+    #[test]
+    fn test_iterator_find_not_found() {
+        let iter = make_array_iterator(vec![JsValue::Smi(1), JsValue::Smi(3)]);
+        let pred = make_native_fn(|args| {
+            let n = args[0].to_number()?;
+            Ok(JsValue::Boolean(n == 99.0))
+        });
+        assert_eq!(iterator_find(&iter, &pred).unwrap(), JsValue::Undefined);
+    }
+
+    // ── iterator_from ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_iterator_from_array() {
+        let arr = JsValue::Array(Rc::new(vec![JsValue::Smi(1), JsValue::Smi(2)]));
+        let iter = iterator_from(&arr).unwrap();
+        let items = iterator_to_vec(&iter).unwrap();
+        assert_eq!(items, vec![JsValue::Smi(1), JsValue::Smi(2)]);
+    }
+
+    #[test]
+    fn test_iterator_from_string() {
+        let s = JsValue::String("ab".into());
+        let iter = iterator_from(&s).unwrap();
+        let items = iterator_to_vec(&iter).unwrap();
+        assert_eq!(
+            items,
+            vec![JsValue::String("a".into()), JsValue::String("b".into())]
+        );
+    }
+
+    #[test]
+    fn test_iterator_from_iterator_passthrough() {
+        let orig = make_array_iterator(vec![JsValue::Smi(5)]);
+        let result = iterator_from(&orig).unwrap();
+        let items = iterator_to_vec(&result).unwrap();
+        assert_eq!(items, vec![JsValue::Smi(5)]);
+    }
+
+    #[test]
+    fn test_iterator_from_non_iterable_errors() {
+        let err = iterator_from(&JsValue::Smi(42)).unwrap_err();
+        assert!(matches!(err, StatorError::TypeError(_)));
     }
 }

--- a/crates/stator_core/src/interpreter/mod.rs
+++ b/crates/stator_core/src/interpreter/mod.rs
@@ -171,8 +171,10 @@ use std::rc::Rc;
 use crate::builtins::error::{pop_call_frame, push_call_frame};
 use crate::bytecode::bytecode_array::{
     BytecodeArray, ConstantPoolEntry, HandlerTableEntry, MAGLEV_TIERING_THRESHOLD,
-    MaglevJitCodeCache, TIERING_THRESHOLD, TURBOFAN_TIERING_THRESHOLD, TurbofanJitCodeCache,
+    TIERING_THRESHOLD, TURBOFAN_TIERING_THRESHOLD,
 };
+#[cfg(all(target_arch = "x86_64", unix))]
+use crate::bytecode::bytecode_array::{MaglevJitCodeCache, TurbofanJitCodeCache};
 use crate::bytecode::bytecodes::{Opcode, Operand, decode_with_byte_offsets};
 use crate::error::{StatorError, StatorResult};
 use crate::inspector::debugger::Debugger;


### PR DESCRIPTION
Closes #300

## Changes

### Iterator Helpers (ES2025)
Added 12 new functions to iterator.rs:
- **Lazy**: `map`, `filter`, `take`, `drop`, `flatMap`
- **Eager**: `reduce`, `toArray`, `forEach`, `some`, `every`, `find`
- **Static**: `Iterator.from`

### Global Object
- Added `globalThis` property pointing to the global object
- Added `Iterator` constructor with `from` static method and `prototype` with all helper methods

### Bug Fix
- Fixed pre-existing unused import warning in `interpreter/mod.rs` by gating platform-specific JIT cache types behind `#[cfg(all(target_arch = \"x86_64\", unix))]`

### Tests
- 34 new tests covering all iterator helpers and install_globals wiring
- All 2106 tests pass (2 pre-existing turbofan failures unchanged)