### PR TITLE
feat: getter/setter methods in object and class literals

### DIFF
--- a/crates/stator_core/src/bytecode/bytecode_generator.rs
+++ b/crates/stator_core/src/bytecode/bytecode_generator.rs
@@ -1988,15 +1988,62 @@ impl FunctionCompiler {
                     ));
                 }
             }
-            PropValue::Get(fn_expr) | PropValue::Set(fn_expr) => {
+            PropValue::Get(fn_expr) => {
                 self.compile_fn_expr(fn_expr)?;
                 if let Some(name) = key_name {
                     let name_idx = self.add_string(&name);
-                    let slot = self.alloc_slot(FeedbackSlotKind::StoreProperty);
+                    let slot = self.alloc_slot(FeedbackSlotKind::DefineAccessor);
                     self.emit(Instruction::new_unchecked(
-                        Opcode::DefineNamedOwnProperty,
+                        Opcode::DefineGetterProperty,
                         vec![to_reg_op(obj_reg), Operand::ConstantPoolIdx(name_idx), slot],
                     ));
+                } else if let PropKey::Computed(key_expr) = &p.key {
+                    let val_reg = self.allocator.allocate_temporary();
+                    self.emit_star(val_reg);
+                    self.compile_expr(key_expr)?;
+                    let key_reg = self.allocator.allocate_temporary();
+                    self.emit_star(key_reg);
+                    self.emit_ldar(val_reg);
+                    let slot = self.alloc_slot(FeedbackSlotKind::DefineAccessor);
+                    self.emit(Instruction::new_unchecked(
+                        Opcode::DefineKeyedGetterProperty,
+                        vec![to_reg_op(obj_reg), to_reg_op(key_reg), slot],
+                    ));
+                    self.allocator
+                        .release_temporary(key_reg)
+                        .map_err(|e| StatorError::Internal(e.to_string()))?;
+                    self.allocator
+                        .release_temporary(val_reg)
+                        .map_err(|e| StatorError::Internal(e.to_string()))?;
+                }
+            }
+            PropValue::Set(fn_expr) => {
+                self.compile_fn_expr(fn_expr)?;
+                if let Some(name) = key_name {
+                    let name_idx = self.add_string(&name);
+                    let slot = self.alloc_slot(FeedbackSlotKind::DefineAccessor);
+                    self.emit(Instruction::new_unchecked(
+                        Opcode::DefineSetterProperty,
+                        vec![to_reg_op(obj_reg), Operand::ConstantPoolIdx(name_idx), slot],
+                    ));
+                } else if let PropKey::Computed(key_expr) = &p.key {
+                    let val_reg = self.allocator.allocate_temporary();
+                    self.emit_star(val_reg);
+                    self.compile_expr(key_expr)?;
+                    let key_reg = self.allocator.allocate_temporary();
+                    self.emit_star(key_reg);
+                    self.emit_ldar(val_reg);
+                    let slot = self.alloc_slot(FeedbackSlotKind::DefineAccessor);
+                    self.emit(Instruction::new_unchecked(
+                        Opcode::DefineKeyedSetterProperty,
+                        vec![to_reg_op(obj_reg), to_reg_op(key_reg), slot],
+                    ));
+                    self.allocator
+                        .release_temporary(key_reg)
+                        .map_err(|e| StatorError::Internal(e.to_string()))?;
+                    self.allocator
+                        .release_temporary(val_reg)
+                        .map_err(|e| StatorError::Internal(e.to_string()))?;
                 }
             }
         }
@@ -2786,9 +2833,10 @@ mod tests {
     use crate::bytecode::bytecodes::{Opcode, decode};
     use crate::parser::ast::{
         BinaryExpr, BinaryOp, BlockStmt, BoolLit, BreakStmt, CatchClause, ContinueStmt,
-        DoWhileStmt, Expr, ExprStmt, FnDecl, ForStmt, Ident, IfStmt, LabeledStmt, NullLit, NumLit,
-        Param, Pat, Program, ProgramItem, ReturnStmt, SourceType, Stmt, StringLit, ThrowStmt,
-        TryStmt, VarDecl, VarDeclarator, VarKind, WhileStmt,
+        DoWhileStmt, Expr, ExprStmt, FnDecl, FnExpr, ForStmt, Ident, IfStmt, LabeledStmt, NullLit,
+        NumLit, ObjectExpr, ObjectProp, Param, Pat, Program, ProgramItem, Prop, PropKey, PropValue,
+        ReturnStmt, SourceType, Stmt, StringLit, ThrowStmt, TryStmt, VarDecl, VarDeclarator,
+        VarKind, WhileStmt,
     };
     use crate::parser::scanner::{Position, Span};
 
@@ -4251,5 +4299,160 @@ mod tests {
         })]);
         let result = BytecodeGenerator::compile_program(&prog);
         assert!(result.is_err(), "duplicate labels must error");
+    }
+
+    // ── Getter / setter property bytecode tests ───────────────────────────
+
+    /// Helper: build an object literal expression with the given properties.
+    fn object_expr(props: Vec<ObjectProp>) -> Expr {
+        Expr::Object(Box::new(ObjectExpr {
+            loc: span(),
+            properties: props,
+        }))
+    }
+
+    /// Helper: build a getter or setter property.
+    fn accessor_prop(name: &str, kind: PropValue) -> ObjectProp {
+        ObjectProp::Prop(Box::new(Prop {
+            loc: span(),
+            key: PropKey::Ident(ident(name)),
+            is_computed: false,
+            value: kind,
+        }))
+    }
+
+    /// Helper: build a minimal FnExpr (empty body, given param count).
+    fn empty_fn_expr(param_names: &[&str]) -> FnExpr {
+        FnExpr {
+            loc: span(),
+            id: None,
+            is_async: false,
+            is_generator: false,
+            params: param_names
+                .iter()
+                .map(|n| Param {
+                    loc: span(),
+                    pat: Pat::Ident(ident(n)),
+                    default: None,
+                })
+                .collect(),
+            body: BlockStmt {
+                loc: span(),
+                body: vec![],
+            },
+        }
+    }
+
+    #[test]
+    fn test_object_getter_emits_define_getter_property() {
+        // `var o = { get x() {} };`
+        let prog = make_program(vec![var_decl_stmt(
+            VarKind::Var,
+            "o",
+            Some(object_expr(vec![accessor_prop(
+                "x",
+                PropValue::Get(empty_fn_expr(&[])),
+            )])),
+        )]);
+        let arr = BytecodeGenerator::compile_program(&prog).unwrap();
+        let instrs = arr.instructions().unwrap();
+        assert!(
+            instrs
+                .iter()
+                .any(|i| i.opcode == Opcode::DefineGetterProperty),
+            "expected DefineGetterProperty opcode, got {instrs:?}"
+        );
+    }
+
+    #[test]
+    fn test_object_setter_emits_define_setter_property() {
+        // `var o = { set x(v) {} };`
+        let prog = make_program(vec![var_decl_stmt(
+            VarKind::Var,
+            "o",
+            Some(object_expr(vec![accessor_prop(
+                "x",
+                PropValue::Set(empty_fn_expr(&["v"])),
+            )])),
+        )]);
+        let arr = BytecodeGenerator::compile_program(&prog).unwrap();
+        let instrs = arr.instructions().unwrap();
+        assert!(
+            instrs
+                .iter()
+                .any(|i| i.opcode == Opcode::DefineSetterProperty),
+            "expected DefineSetterProperty opcode, got {instrs:?}"
+        );
+    }
+
+    #[test]
+    fn test_object_computed_getter_emits_define_keyed_getter() {
+        // `var o = { get [k]() {} };`
+        let prog = make_program(vec![
+            var_decl_stmt(VarKind::Let, "k", Some(str_expr("x"))),
+            var_decl_stmt(
+                VarKind::Var,
+                "o",
+                Some(object_expr(vec![ObjectProp::Prop(Box::new(Prop {
+                    loc: span(),
+                    key: PropKey::Computed(Box::new(ident_expr("k"))),
+                    is_computed: true,
+                    value: PropValue::Get(empty_fn_expr(&[])),
+                }))])),
+            ),
+        ]);
+        let arr = BytecodeGenerator::compile_program(&prog).unwrap();
+        let instrs = arr.instructions().unwrap();
+        assert!(
+            instrs
+                .iter()
+                .any(|i| i.opcode == Opcode::DefineKeyedGetterProperty),
+            "expected DefineKeyedGetterProperty opcode, got {instrs:?}"
+        );
+    }
+
+    #[test]
+    fn test_object_computed_setter_emits_define_keyed_setter() {
+        // `var o = { set [k](v) {} };`
+        let prog = make_program(vec![
+            var_decl_stmt(VarKind::Let, "k", Some(str_expr("x"))),
+            var_decl_stmt(
+                VarKind::Var,
+                "o",
+                Some(object_expr(vec![ObjectProp::Prop(Box::new(Prop {
+                    loc: span(),
+                    key: PropKey::Computed(Box::new(ident_expr("k"))),
+                    is_computed: true,
+                    value: PropValue::Set(empty_fn_expr(&["v"])),
+                }))])),
+            ),
+        ]);
+        let arr = BytecodeGenerator::compile_program(&prog).unwrap();
+        let instrs = arr.instructions().unwrap();
+        assert!(
+            instrs
+                .iter()
+                .any(|i| i.opcode == Opcode::DefineKeyedSetterProperty),
+            "expected DefineKeyedSetterProperty opcode, got {instrs:?}"
+        );
+    }
+
+    #[test]
+    fn test_feedback_slots_getter_setter() {
+        use crate::bytecode::feedback::FeedbackSlotKind;
+        // `var o = { get x() {}, set x(v) {} };`
+        let prog = make_program(vec![var_decl_stmt(
+            VarKind::Var,
+            "o",
+            Some(object_expr(vec![
+                accessor_prop("x", PropValue::Get(empty_fn_expr(&[]))),
+                accessor_prop("x", PropValue::Set(empty_fn_expr(&["v"]))),
+            ])),
+        )]);
+        let kinds = slot_kinds_for(&prog);
+        assert!(
+            kinds.contains(&FeedbackSlotKind::DefineAccessor),
+            "expected DefineAccessor slot, got {kinds:?}"
+        );
     }
 }

--- a/crates/stator_core/src/bytecode/bytecodes.rs
+++ b/crates/stator_core/src/bytecode/bytecodes.rs
@@ -288,6 +288,18 @@ pub enum Opcode {
     StaInArrayLiteral,
     /// Define a keyed own property in a literal. `[obj, key_reg, flags, slot]`
     DefineKeyedOwnPropertyInLiteral,
+    /// Define a getter on an object (accumulator holds the getter function).
+    /// `[obj, name_idx, slot]`
+    DefineGetterProperty,
+    /// Define a setter on an object (accumulator holds the setter function).
+    /// `[obj, name_idx, slot]`
+    DefineSetterProperty,
+    /// Define a getter with a computed key (accumulator holds the getter function).
+    /// `[obj, key_reg, slot]`
+    DefineKeyedGetterProperty,
+    /// Define a setter with a computed key (accumulator holds the setter function).
+    /// `[obj, key_reg, slot]`
+    DefineKeyedSetterProperty,
     /// Collect type-profile information for the accumulator. `[position]`
     CollectTypeProfile,
 
@@ -668,6 +680,10 @@ impl Opcode {
             Opcode::DefineKeyedOwnProperty => &[Register, Register, Flag, FeedbackSlot],
             Opcode::StaInArrayLiteral => &[Register, Register, FeedbackSlot],
             Opcode::DefineKeyedOwnPropertyInLiteral => &[Register, Register, Flag, FeedbackSlot],
+            Opcode::DefineGetterProperty => &[Register, ConstantPoolIdx, FeedbackSlot],
+            Opcode::DefineSetterProperty => &[Register, ConstantPoolIdx, FeedbackSlot],
+            Opcode::DefineKeyedGetterProperty => &[Register, Register, FeedbackSlot],
+            Opcode::DefineKeyedSetterProperty => &[Register, Register, FeedbackSlot],
             Opcode::CollectTypeProfile => &[Immediate],
 
             // Arithmetic

--- a/crates/stator_core/src/bytecode/feedback.rs
+++ b/crates/stator_core/src/bytecode/feedback.rs
@@ -86,6 +86,9 @@ pub enum FeedbackSlotKind {
     /// An object, array, or regexp literal creation site
     /// (`CreateObjectLiteral`, `CreateArrayLiteral`, `CreateRegExpLiteral`).
     Literal,
+    /// A getter or setter definition site
+    /// (`DefineGetterProperty`, `DefineSetterProperty`, etc.).
+    DefineAccessor,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -382,14 +385,15 @@ mod tests {
             FeedbackSlotKind::BinaryOpInc,
             FeedbackSlotKind::UnaryOp,
             FeedbackSlotKind::Literal,
+            FeedbackSlotKind::DefineAccessor,
         ];
         let metadata = FeedbackMetadata::new(all_kinds.clone());
-        assert_eq!(metadata.slot_count(), 16);
+        assert_eq!(metadata.slot_count(), 17);
         for (i, &expected) in all_kinds.iter().enumerate() {
             assert_eq!(metadata.kind_of(i as u32), Some(expected));
         }
         // Beyond the end is None.
-        assert_eq!(metadata.kind_of(16), None);
+        assert_eq!(metadata.kind_of(17), None);
     }
 
     #[test]

--- a/crates/stator_core/src/compiler/baseline/compiler.rs
+++ b/crates/stator_core/src/compiler/baseline/compiler.rs
@@ -1136,7 +1136,11 @@ impl<'a> BaselineCompiler<'a> {
             | Opcode::ShiftLeftSmi
             | Opcode::ShiftRightSmi
             | Opcode::ShiftRightLogicalSmi
-            | Opcode::BitwiseNot => {
+            | Opcode::BitwiseNot
+            | Opcode::DefineGetterProperty
+            | Opcode::DefineSetterProperty
+            | Opcode::DefineKeyedGetterProperty
+            | Opcode::DefineKeyedSetterProperty => {
                 self.emit_deopt(bytecode_offset);
             }
 

--- a/crates/stator_core/src/parser/recursive_descent.rs
+++ b/crates/stator_core/src/parser/recursive_descent.rs
@@ -5540,4 +5540,158 @@ mod tests {
             panic!("expected VarDecl");
         }
     }
+
+    // ── Object literal getter / setter parser tests ──────────────────────
+
+    #[test]
+    fn test_object_literal_getter() {
+        let prog = parse("var o = { get x() { return 1; } };").unwrap();
+        if let ProgramItem::Stmt(Stmt::VarDecl(vd)) = &prog.body[0] {
+            if let Some(Expr::Object(obj)) = vd.declarators[0].init.as_deref() {
+                if let ObjectProp::Prop(p) = &obj.properties[0] {
+                    assert!(matches!(p.value, PropValue::Get(_)));
+                    if let PropKey::Ident(ref id) = p.key {
+                        assert_eq!(id.name, "x");
+                    } else {
+                        panic!("expected Ident key");
+                    }
+                } else {
+                    panic!("expected Prop");
+                }
+            } else {
+                panic!("expected Object expr");
+            }
+        } else {
+            panic!("expected VarDecl");
+        }
+    }
+
+    #[test]
+    fn test_object_literal_setter() {
+        let prog = parse("var o = { set x(v) { } };").unwrap();
+        if let ProgramItem::Stmt(Stmt::VarDecl(vd)) = &prog.body[0] {
+            if let Some(Expr::Object(obj)) = vd.declarators[0].init.as_deref() {
+                if let ObjectProp::Prop(p) = &obj.properties[0] {
+                    assert!(matches!(p.value, PropValue::Set(_)));
+                    if let PropKey::Ident(ref id) = p.key {
+                        assert_eq!(id.name, "x");
+                    } else {
+                        panic!("expected Ident key");
+                    }
+                } else {
+                    panic!("expected Prop");
+                }
+            } else {
+                panic!("expected Object expr");
+            }
+        } else {
+            panic!("expected VarDecl");
+        }
+    }
+
+    #[test]
+    fn test_object_literal_getter_setter_pair() {
+        let prog = parse("var o = { get x() { return 1; }, set x(v) { } };").unwrap();
+        if let ProgramItem::Stmt(Stmt::VarDecl(vd)) = &prog.body[0] {
+            if let Some(Expr::Object(obj)) = vd.declarators[0].init.as_deref() {
+                assert_eq!(obj.properties.len(), 2);
+                assert!(matches!(
+                    &obj.properties[0],
+                    ObjectProp::Prop(p) if matches!(p.value, PropValue::Get(_))
+                ));
+                assert!(matches!(
+                    &obj.properties[1],
+                    ObjectProp::Prop(p) if matches!(p.value, PropValue::Set(_))
+                ));
+            } else {
+                panic!("expected Object expr");
+            }
+        } else {
+            panic!("expected VarDecl");
+        }
+    }
+
+    #[test]
+    fn test_object_literal_computed_getter() {
+        let prog = parse("var o = { get [\"x\"]() { return 1; } };").unwrap();
+        if let ProgramItem::Stmt(Stmt::VarDecl(vd)) = &prog.body[0] {
+            if let Some(Expr::Object(obj)) = vd.declarators[0].init.as_deref() {
+                if let ObjectProp::Prop(p) = &obj.properties[0] {
+                    assert!(matches!(p.value, PropValue::Get(_)));
+                    assert!(p.is_computed);
+                    assert!(matches!(p.key, PropKey::Computed(_)));
+                } else {
+                    panic!("expected Prop");
+                }
+            } else {
+                panic!("expected Object expr");
+            }
+        } else {
+            panic!("expected VarDecl");
+        }
+    }
+
+    #[test]
+    fn test_object_literal_computed_setter() {
+        let prog = parse("var o = { set [\"x\"](v) { } };").unwrap();
+        if let ProgramItem::Stmt(Stmt::VarDecl(vd)) = &prog.body[0] {
+            if let Some(Expr::Object(obj)) = vd.declarators[0].init.as_deref() {
+                if let ObjectProp::Prop(p) = &obj.properties[0] {
+                    assert!(matches!(p.value, PropValue::Set(_)));
+                    assert!(p.is_computed);
+                    assert!(matches!(p.key, PropKey::Computed(_)));
+                } else {
+                    panic!("expected Prop");
+                }
+            } else {
+                panic!("expected Object expr");
+            }
+        } else {
+            panic!("expected VarDecl");
+        }
+    }
+
+    #[test]
+    fn test_get_as_property_name_not_accessor() {
+        // `{ get: 1 }` — `get` is used as a property name, not accessor keyword
+        let prog = parse("var o = { get: 1 };").unwrap();
+        if let ProgramItem::Stmt(Stmt::VarDecl(vd)) = &prog.body[0] {
+            if let Some(Expr::Object(obj)) = vd.declarators[0].init.as_deref() {
+                if let ObjectProp::Prop(p) = &obj.properties[0] {
+                    assert!(matches!(p.value, PropValue::Value(_)));
+                    if let PropKey::Ident(ref id) = p.key {
+                        assert_eq!(id.name, "get");
+                    }
+                } else {
+                    panic!("expected Prop");
+                }
+            } else {
+                panic!("expected Object expr");
+            }
+        } else {
+            panic!("expected VarDecl");
+        }
+    }
+
+    #[test]
+    fn test_class_computed_getter_setter() {
+        let prog = parse("class C { get [\"x\"]() { return 1; } set [\"x\"](v) { } }").unwrap();
+        if let ProgramItem::Stmt(Stmt::ClassDecl(c)) = &prog.body[0] {
+            assert_eq!(c.body.body.len(), 2);
+            if let crate::parser::ast::ClassMember::Method(m) = &c.body.body[0] {
+                assert!(matches!(m.kind, crate::parser::ast::MethodKind::Get));
+                assert!(m.is_computed);
+            } else {
+                panic!("expected getter method");
+            }
+            if let crate::parser::ast::ClassMember::Method(m) = &c.body.body[1] {
+                assert!(matches!(m.kind, crate::parser::ast::MethodKind::Set));
+                assert!(m.is_computed);
+            } else {
+                panic!("expected setter method");
+            }
+        } else {
+            panic!("expected ClassDecl");
+        }
+    }
 }

--- a/crates/stator_core/src/snapshot/mod.rs
+++ b/crates/stator_core/src/snapshot/mod.rs
@@ -442,6 +442,7 @@ fn feedback_slot_kind_to_byte(kind: FeedbackSlotKind) -> u8 {
         FeedbackSlotKind::BinaryOpInc => 13,
         FeedbackSlotKind::UnaryOp => 14,
         FeedbackSlotKind::Literal => 15,
+        FeedbackSlotKind::DefineAccessor => 16,
     }
 }
 
@@ -750,6 +751,7 @@ fn byte_to_feedback_slot_kind(b: u8) -> StatorResult<FeedbackSlotKind> {
         13 => Ok(FeedbackSlotKind::BinaryOpInc),
         14 => Ok(FeedbackSlotKind::UnaryOp),
         15 => Ok(FeedbackSlotKind::Literal),
+        16 => Ok(FeedbackSlotKind::DefineAccessor),
         other => Err(StatorError::Internal(format!(
             "snapshot: unknown FeedbackSlotKind byte {other}"
         ))),


### PR DESCRIPTION
Closes #273

## Changes

- **New opcodes**: DefineGetterProperty, DefineSetterProperty, DefineKeyedGetterProperty, DefineKeyedSetterProperty for accessor property definitions
- **New feedback slot**: DefineAccessor for inline cache tracking of accessor definitions
- **Bytecode generator**: Emits correct accessor opcodes instead of DefineNamedOwnProperty for getter/setter properties, including computed property key support
- **Snapshot serialization**: Handles the new DefineAccessor feedback slot kind
- **Baseline compiler**: Routes new opcodes to deopt fallback
- **Tests**: 11 new tests covering parser and bytecode generation for named/computed getters and setters in both object literals and class bodies