### PR TITLE
feat: async generators and for-await-of

### DIFF
--- a/crates/stator_core/src/bytecode/bytecode_array.rs
+++ b/crates/stator_core/src/bytecode/bytecode_array.rs
@@ -221,6 +221,8 @@ pub struct BytecodeArray {
     /// [`crate::objects::value::JsValue::Generator`] without executing the
     /// body immediately.
     is_generator: bool,
+    /// `true` if this bytecode belongs to an async function or async generator.
+    is_async: bool,
     // ─── Tiering state (shared across clones via Rc / Arc) ───────────────────
     /// Number of times this function has been invoked.
     ///
@@ -270,6 +272,7 @@ impl PartialEq for BytecodeArray {
             && self.feedback_metadata == other.feedback_metadata
             && self.handler_table == other.handler_table
             && self.is_generator == other.is_generator
+            && self.is_async == other.is_async
     }
 }
 
@@ -305,6 +308,7 @@ impl BytecodeArray {
             feedback_metadata,
             handler_table,
             is_generator: false,
+            is_async: false,
             invocation_count: Rc::new(Cell::new(0)),
             jit_code: Rc::new(RefCell::new(None)),
             maglev_jit_code: Arc::new(Mutex::new(None)),
@@ -332,6 +336,21 @@ impl BytecodeArray {
     /// Returns `true` if this bytecode belongs to a `function*` generator.
     pub fn is_generator(&self) -> bool {
         self.is_generator
+    }
+
+    /// Mark this [`BytecodeArray`] as belonging to an async function.
+    ///
+    /// When combined with [`BytecodeArray::with_generator_flag`] this marks
+    /// the function as an async generator (`async function*`).
+    pub fn with_async_flag(mut self, flag: bool) -> Self {
+        self.is_async = flag;
+        self
+    }
+
+    /// Returns `true` if this bytecode belongs to an `async function` or
+    /// `async function*`.
+    pub fn is_async(&self) -> bool {
+        self.is_async
     }
 
     /// The raw encoded bytecode bytes.

--- a/crates/stator_core/src/bytecode/bytecode_generator.rs
+++ b/crates/stator_core/src/bytecode/bytecode_generator.rs
@@ -183,6 +183,11 @@ struct FunctionCompiler {
     /// [`BytecodeArray::with_generator_flag`]) and enables `yield` /
     /// `yield*` compilation.
     is_generator: bool,
+    /// `true` when compiling an `async function` or `async function*` body.
+    ///
+    /// Affects `finalize` (marks the [`BytecodeArray`] with
+    /// [`BytecodeArray::with_async_flag`]) and enables `await` compilation.
+    is_async: bool,
     /// Counter used to generate unique `suspend_id` immediates for each
     /// [`Opcode::SuspendGenerator`] instruction in this function.
     yield_suspend_id: u32,
@@ -214,6 +219,7 @@ impl FunctionCompiler {
             slot_kinds: Vec::new(),
             handler_table: Vec::new(),
             is_generator: false,
+            is_async: false,
             yield_suspend_id: 0,
             is_program: false,
         };
@@ -523,7 +529,8 @@ impl FunctionCompiler {
                 "async functions are not yet supported".into(),
             ));
         }
-        let func_array = compile_function(&decl.params, &decl.body, decl.is_generator)?;
+        let func_array =
+            compile_function(&decl.params, &decl.body, decl.is_generator, decl.is_async)?;
         let pool_idx = self.add_constant_raw(ConstantPoolEntry::Function(Box::new(func_array)));
         // Emit CreateClosure: [func_idx, slot, flags]
         let slot = self.alloc_slot(FeedbackSlotKind::CreateClosure);
@@ -1051,7 +1058,14 @@ impl FunctionCompiler {
                 }
                 self.compile_yield(y)
             }
-            Expr::Await(_) => Err(StatorError::Internal("await is not yet supported".into())),
+            Expr::Await(a) => {
+                if !self.is_async {
+                    return Err(StatorError::Internal(
+                        "await expression outside of an async function".into(),
+                    ));
+                }
+                self.compile_await(a)
+            }
 
             Expr::TaggedTemplate(_) => Err(StatorError::Internal(
                 "tagged template literals are not yet supported".into(),
@@ -1833,7 +1847,7 @@ impl FunctionCompiler {
                 "async function expressions are not yet supported".into(),
             ));
         }
-        let func_array = compile_function(&f.params, &f.body, f.is_generator)?;
+        let func_array = compile_function(&f.params, &f.body, f.is_generator, f.is_async)?;
         let pool_idx = self.add_constant_raw(ConstantPoolEntry::Function(Box::new(func_array)));
         let slot = self.alloc_slot(FeedbackSlotKind::CreateClosure);
         self.emit(Instruction::new_unchecked(
@@ -1866,7 +1880,7 @@ impl FunctionCompiler {
                 }
             }
         };
-        let func_array = compile_function(&a.params, &body_block, false)?;
+        let func_array = compile_function(&a.params, &body_block, false, false)?;
         let pool_idx = self.add_constant_raw(ConstantPoolEntry::Function(Box::new(func_array)));
         let slot = self.alloc_slot(FeedbackSlotKind::CreateClosure);
         self.emit(Instruction::new_unchecked(
@@ -2210,6 +2224,39 @@ impl FunctionCompiler {
 
         // ResumeGenerator [gen, regs_start, regs_count]
         // After this, acc = value sent by caller's .next(sent).
+        self.emit(Instruction::new_unchecked(
+            Opcode::ResumeGenerator,
+            vec![dummy, dummy, Operand::RegisterCount(0)],
+        ));
+
+        Ok(())
+    }
+
+    /// Compile an `await expr` expression inside an async (generator) function.
+    ///
+    /// Uses the same suspend/resume mechanism as `yield` so the runtime can
+    /// resolve the awaited value and resume execution with the result.
+    fn compile_await(&mut self, expr: &crate::parser::ast::AwaitExpr) -> StatorResult<()> {
+        // Evaluate the awaited expression → acc.
+        self.compile_expr(&expr.argument)?;
+
+        let dummy = Operand::Register(0);
+
+        // SuspendGenerator [gen, regs_start, regs_count, suspend_id]
+        let suspend_id = self.yield_suspend_id;
+        self.yield_suspend_id += 1;
+        self.emit(Instruction::new_unchecked(
+            Opcode::SuspendGenerator,
+            vec![
+                dummy,
+                dummy,
+                Operand::RegisterCount(0),
+                Operand::Immediate(suspend_id as i32),
+            ],
+        ));
+
+        // ResumeGenerator [gen, regs_start, regs_count]
+        // After this, acc = resolved value of the awaited expression.
         self.emit(Instruction::new_unchecked(
             Opcode::ResumeGenerator,
             vec![dummy, dummy, Operand::RegisterCount(0)],
@@ -2705,7 +2752,9 @@ impl FunctionCompiler {
             feedback_metadata,
             self.handler_table,
         );
-        Ok(ba.with_generator_flag(self.is_generator))
+        Ok(ba
+            .with_generator_flag(self.is_generator)
+            .with_async_flag(self.is_async))
     }
 }
 
@@ -2768,15 +2817,24 @@ fn resolve_jumps(instructions: &mut [Instruction], labels: &[Label]) -> StatorRe
 ///   [`BytecodeArray::with_generator_flag(true)`][BytecodeArray::with_generator_flag].
 /// - A [`Opcode::SwitchOnGeneratorState`] prologue is emitted before the body
 ///   so that resumed executions jump directly to the saved resume point.
+///
+/// When `is_async` is `true`:
+/// - The produced [`BytecodeArray`] is marked with
+///   [`BytecodeArray::with_async_flag(true)`][BytecodeArray::with_async_flag].
+/// - `await` expressions are compiled using the same suspend/resume mechanism
+///   as `yield`.
 fn compile_function(
     params: &[crate::parser::ast::Param],
     body: &BlockStmt,
     is_generator: bool,
+    is_async: bool,
 ) -> StatorResult<BytecodeArray> {
     let mut compiler = FunctionCompiler::new(params)?;
     compiler.is_generator = is_generator;
+    compiler.is_async = is_async;
 
-    // Generator prologue: jump to the saved resume point on re-entry.
+    // Generator / async-generator prologue: jump to the saved resume point on
+    // re-entry.
     if is_generator {
         compiler.emit(Instruction::new_unchecked(
             Opcode::SwitchOnGeneratorState,
@@ -3355,6 +3413,7 @@ mod tests {
                 },
             ],
             &body,
+            false,
             false,
         )
         .unwrap();
@@ -4525,6 +4584,176 @@ mod tests {
         assert!(
             opcodes.contains(&Opcode::PopContext),
             "expected PopContext, got {opcodes:?}"
+        );
+    }
+
+    // ── Async generator functions ─────────────────────────────────────────────
+
+    /// Helper: build a `FnDecl` for an async generator function.
+    fn make_async_generator_fn_decl(name: &str, body: Vec<Stmt>) -> FnDecl {
+        FnDecl {
+            loc: span(),
+            id: Some(ident(name)),
+            params: vec![],
+            body: BlockStmt { loc: span(), body },
+            is_generator: true,
+            is_async: true,
+        }
+    }
+
+    /// Helper: build an `await expr` expression statement.
+    fn await_stmt(arg: Expr) -> Stmt {
+        use crate::parser::ast::{AwaitExpr, ExprStmt};
+        Stmt::Expr(ExprStmt {
+            loc: span(),
+            expr: Box::new(Expr::Await(Box::new(AwaitExpr {
+                loc: span(),
+                argument: Box::new(arg),
+            }))),
+        })
+    }
+
+    #[test]
+    fn test_async_generator_function_compiles() {
+        // `async function* gen() { yield 1; yield 2; }`
+        let decl = make_async_generator_fn_decl(
+            "gen",
+            vec![
+                yield_stmt(Some(num_expr(1.0)), false),
+                yield_stmt(Some(num_expr(2.0)), false),
+            ],
+        );
+        let prog = make_program(vec![Stmt::FnDecl(Box::new(decl))]);
+        let arr = BytecodeGenerator::compile_program(&prog).unwrap();
+        let pool = arr.constant_pool();
+        assert!(!pool.is_empty());
+        if let crate::bytecode::bytecode_array::ConstantPoolEntry::Function(ba) = &pool[0] {
+            assert!(ba.is_generator(), "must be marked as generator");
+            assert!(ba.is_async(), "must be marked as async");
+            let inner_instrs = ba.instructions().unwrap();
+            assert_eq!(
+                inner_instrs[0].opcode,
+                Opcode::SwitchOnGeneratorState,
+                "async generator body must begin with SwitchOnGeneratorState"
+            );
+            assert!(
+                inner_instrs
+                    .iter()
+                    .any(|i| i.opcode == Opcode::SuspendGenerator),
+                "async generator body must contain SuspendGenerator"
+            );
+        } else {
+            panic!("constant pool[0] should be a Function");
+        }
+    }
+
+    #[test]
+    fn test_async_generator_with_await_compiles() {
+        // `async function* gen() { await x; yield 1; }`
+        let decl = make_async_generator_fn_decl(
+            "gen",
+            vec![
+                await_stmt(ident_expr("x")),
+                yield_stmt(Some(num_expr(1.0)), false),
+            ],
+        );
+        let prog = make_program(vec![Stmt::FnDecl(Box::new(decl))]);
+        let arr = BytecodeGenerator::compile_program(&prog).unwrap();
+        let pool = arr.constant_pool();
+        if let crate::bytecode::bytecode_array::ConstantPoolEntry::Function(ba) = &pool[0] {
+            assert!(ba.is_async(), "must be marked as async");
+            let inner_instrs = ba.instructions().unwrap();
+            // The body should have two SuspendGenerator instructions: one for
+            // await (suspend/resume) and one for yield.
+            let suspend_count = inner_instrs
+                .iter()
+                .filter(|i| i.opcode == Opcode::SuspendGenerator)
+                .count();
+            assert!(
+                suspend_count >= 2,
+                "expected >= 2 SuspendGenerator (1 await + 1 yield), got {suspend_count}"
+            );
+        } else {
+            panic!("constant pool[0] should be a Function");
+        }
+    }
+
+    #[test]
+    fn test_async_generator_expr_compiles() {
+        // `var f = async function*() { yield 1; };`
+        use crate::parser::ast::FnExpr;
+        let fn_expr = Expr::Fn(Box::new(FnExpr {
+            loc: span(),
+            id: None,
+            params: vec![],
+            body: BlockStmt {
+                loc: span(),
+                body: vec![yield_stmt(Some(num_expr(1.0)), false)],
+            },
+            is_generator: true,
+            is_async: true,
+        }));
+        let prog = make_program(vec![var_decl_stmt(VarKind::Var, "f", Some(fn_expr))]);
+        let arr = BytecodeGenerator::compile_program(&prog).unwrap();
+        let pool = arr.constant_pool();
+        if let crate::bytecode::bytecode_array::ConstantPoolEntry::Function(ba) = &pool[0] {
+            assert!(ba.is_generator(), "must be marked as generator");
+            assert!(ba.is_async(), "must be marked as async");
+        } else {
+            panic!("constant pool[0] should be a Function");
+        }
+    }
+
+    #[test]
+    fn test_for_await_of_compiles_with_get_async_iterator() {
+        // `for await (const x of someArr) { }` — verify GetAsyncIterator.
+        use crate::parser::ast::{ForInOfLeft, ForOfStmt, VarDecl, VarDeclarator, VarKind};
+        let prog = make_program(vec![Stmt::ForOf(ForOfStmt {
+            loc: span(),
+            is_await: true,
+            left: ForInOfLeft::VarDecl(VarDecl {
+                loc: span(),
+                kind: VarKind::Const,
+                declarators: vec![VarDeclarator {
+                    loc: span(),
+                    id: Pat::Ident(ident("x")),
+                    init: None,
+                }],
+            }),
+            right: Box::new(ident_expr("someArr")),
+            body: Box::new(Stmt::Empty(crate::parser::ast::EmptyStmt { loc: span() })),
+        })]);
+        let arr = BytecodeGenerator::compile_program(&prog).unwrap();
+        let instrs = arr.instructions().unwrap();
+        assert!(
+            instrs.iter().any(|i| i.opcode == Opcode::GetAsyncIterator),
+            "for-await-of must emit GetAsyncIterator, got {instrs:?}"
+        );
+    }
+
+    #[test]
+    fn test_async_generator_call_returns_generator_value() {
+        // `async function* gen() { yield 1; } return gen();`
+        use crate::objects::value::JsValue;
+        let decl =
+            make_async_generator_fn_decl("gen", vec![yield_stmt(Some(num_expr(1.0)), false)]);
+        let prog = make_program(vec![
+            Stmt::FnDecl(Box::new(decl)),
+            Stmt::Return(ReturnStmt {
+                loc: span(),
+                argument: Some(Box::new(Expr::Call(Box::new(
+                    crate::parser::ast::CallExpr {
+                        loc: span(),
+                        callee: Box::new(ident_expr("gen")),
+                        arguments: vec![],
+                    },
+                )))),
+            }),
+        ]);
+        let result = run(&prog);
+        assert!(
+            matches!(result, JsValue::Generator(_)),
+            "calling an async generator must return JsValue::Generator, got {result:?}"
         );
     }
 }

--- a/crates/stator_core/src/parser/recursive_descent.rs
+++ b/crates/stator_core/src/parser/recursive_descent.rs
@@ -36,7 +36,7 @@ use crate::parser::ast::{
     Param, Pat, Program, ProgramItem, Prop, PropKey, PropValue, RegExpLit, RestElement, ReturnStmt,
     SequenceExpr, SourceLocation, SourceType, SpreadElement, Stmt, StringLit, SwitchCase,
     SwitchStmt, TemplateElement, TemplateLit, ThrowStmt, TryStmt, UnaryExpr, UnaryOp, UpdateExpr,
-    UpdateOp, VarDecl, VarDeclarator, VarKind, WhileStmt, WithStmt,
+    UpdateOp, VarDecl, VarDeclarator, VarKind, WhileStmt, WithStmt, YieldExpr,
 };
 use crate::parser::scanner::{Scanner, Span, Token, TokenKind, TokenValue};
 
@@ -432,6 +432,10 @@ impl<'src> Parser<'src> {
     fn parse_for(&mut self) -> StatorResult<Stmt> {
         let start = self.current_span();
         self.bump()?; // 'for'
+
+        // `for await (…)` — async iteration.
+        let is_await = self.eat(TokenKind::Await)?;
+
         self.expect(TokenKind::LeftParen)?;
 
         // ── var / let / const  ───────────────────────────────────────────
@@ -468,7 +472,7 @@ impl<'src> Parser<'src> {
                 return if is_of {
                     Ok(Stmt::ForOf(ForOfStmt {
                         loc: Self::merge_spans(start, end),
-                        is_await: false,
+                        is_await,
                         left,
                         right: Box::new(right),
                         body: Box::new(body),
@@ -523,7 +527,7 @@ impl<'src> Parser<'src> {
             return if is_of {
                 Ok(Stmt::ForOf(ForOfStmt {
                     loc: Self::merge_spans(start, end),
-                    is_await: false,
+                    is_await,
                     left,
                     right: Box::new(right),
                     body: Box::new(body),
@@ -1799,6 +1803,34 @@ impl<'src> Parser<'src> {
             // parser can handle `async` as an identifier or `async function`.
             self.scanner = saved_scanner;
             self.current = saved_current;
+        }
+
+        // ── yield expression ─────────────────────────────────────────────
+        // `yield`, `yield expr`, `yield* expr`
+        if self.peek_kind() == TokenKind::Yield {
+            let yield_tok = self.bump()?; // consume `yield`
+            let delegate = self.eat(TokenKind::Star)?;
+
+            // Yield with no argument when followed by a statement terminator.
+            let argument = if !delegate
+                && (self.peek_kind() == TokenKind::Semicolon
+                    || self.peek_kind() == TokenKind::RightBrace
+                    || self.peek_kind() == TokenKind::RightParen
+                    || self.peek_kind() == TokenKind::RightBracket
+                    || self.peek_kind() == TokenKind::Eof
+                    || self.current.had_line_terminator_before)
+            {
+                None
+            } else {
+                Some(Box::new(self.parse_assignment_expr()?))
+            };
+
+            let end = argument.as_ref().map(|a| a.loc()).unwrap_or(yield_tok.span);
+            return Ok(Expr::Yield(Box::new(YieldExpr {
+                loc: Self::merge_spans(start, end),
+                delegate,
+                argument,
+            })));
         }
 
         // ── Arrow function detection ─────────────────────────────────────
@@ -5742,6 +5774,68 @@ mod tests {
             assert!(matches!(*outer.body, Stmt::With(_)));
         } else {
             panic!("expected nested with");
+        }
+    }
+
+    // ── Async generator parsing ───────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_async_generator_declaration() {
+        let prog = parse("async function* gen() { yield 1; }").unwrap();
+        if let ProgramItem::Stmt(Stmt::FnDecl(f)) = &prog.body[0] {
+            assert!(f.is_async, "should be async");
+            assert!(f.is_generator, "should be generator");
+            assert_eq!(f.id.as_ref().unwrap().name, "gen");
+        } else {
+            panic!("expected async generator FnDecl");
+        }
+    }
+
+    #[test]
+    fn test_parse_async_generator_expression() {
+        let prog = parse("var f = async function*() { yield 1; };").unwrap();
+        if let ProgramItem::Stmt(Stmt::VarDecl(v)) = &prog.body[0] {
+            if let Some(init) = &v.declarators[0].init {
+                if let Expr::Fn(f) = init.as_ref() {
+                    assert!(f.is_async, "should be async");
+                    assert!(f.is_generator, "should be generator");
+                } else {
+                    panic!("expected FnExpr");
+                }
+            } else {
+                panic!("expected init");
+            }
+        } else {
+            panic!("expected VarDecl");
+        }
+    }
+
+    #[test]
+    fn test_parse_for_await_of() {
+        let prog = parse("async function* f() { for await (const x of arr) { } }").unwrap();
+        if let ProgramItem::Stmt(Stmt::FnDecl(f)) = &prog.body[0] {
+            assert!(f.is_async);
+            assert!(f.is_generator);
+            if let Stmt::ForOf(for_of) = &f.body.body[0] {
+                assert!(for_of.is_await, "for-of should have is_await = true");
+            } else {
+                panic!("expected ForOf statement, got {:?}", f.body.body[0]);
+            }
+        } else {
+            panic!("expected FnDecl");
+        }
+    }
+
+    #[test]
+    fn test_parse_for_of_without_await() {
+        let prog = parse("for (const x of arr) { }").unwrap();
+        if let ProgramItem::Stmt(Stmt::ForOf(for_of)) = &prog.body[0] {
+            assert!(
+                !for_of.is_await,
+                "regular for-of should have is_await = false"
+            );
+        } else {
+            panic!("expected ForOf statement");
         }
     }
 }


### PR DESCRIPTION
Closes #276

## Changes

- **Parser**: Parse yield / yield* expressions, or await (const x of iterable) { }, and sync function* (declaration + expression)
- **BytecodeArray**: Add is_async flag with with_async_flag()/is_async() accessors
- **Compiler**: Allow sync function* through the bytecode generator, compile wait using the same SuspendGenerator/ResumeGenerator mechanism as yield
- **Tests**: 9 new tests covering async generator declarations, expressions, await inside async generators, for-await-of, and runtime generator creation