### PR TITLE
feat: spec-complete RegExp builtins

### DIFF
--- a/crates/stator_core/src/builtins/install_globals.rs
+++ b/crates/stator_core/src/builtins/install_globals.rs
@@ -44,6 +44,7 @@ use crate::builtins::math::{
     math_min, math_pow, math_random, math_round, math_sign, math_sin, math_sinh, math_sqrt,
     math_tan, math_tanh, math_trunc,
 };
+use crate::builtins::regexp::regexp_construct;
 use crate::builtins::set::{
     set_add, set_clear, set_delete, set_entries, set_from_iterable, set_has, set_keys, set_new,
     set_size, set_values,
@@ -59,8 +60,9 @@ use crate::builtins::string::{
 };
 use crate::builtins::symbol::{
     SYMBOL_ASYNC_ITERATOR, SYMBOL_HAS_INSTANCE, SYMBOL_IS_CONCAT_SPREADABLE, SYMBOL_ITERATOR,
-    SYMBOL_MATCH, SYMBOL_REPLACE, SYMBOL_SEARCH, SYMBOL_SPECIES, SYMBOL_SPLIT, SYMBOL_TO_PRIMITIVE,
-    SYMBOL_TO_STRING_TAG, SYMBOL_UNSCOPABLES, symbol_create, symbol_for, symbol_key_for,
+    SYMBOL_MATCH, SYMBOL_MATCH_ALL, SYMBOL_REPLACE, SYMBOL_SEARCH, SYMBOL_SPECIES, SYMBOL_SPLIT,
+    SYMBOL_TO_PRIMITIVE, SYMBOL_TO_STRING_TAG, SYMBOL_UNSCOPABLES, symbol_create, symbol_for,
+    symbol_key_for,
 };
 use crate::builtins::weak_map::{
     weak_map_delete, weak_map_get, weak_map_has, weak_map_new, weak_map_set,
@@ -921,6 +923,7 @@ fn make_symbol() -> JsValue {
         "asyncIterator".into(),
         JsValue::Symbol(SYMBOL_ASYNC_ITERATOR),
     );
+    props.insert("matchAll".into(), JsValue::Symbol(SYMBOL_MATCH_ALL));
 
     // ── The callable Symbol(desc?) ────────────────────────────────────────
     //
@@ -2035,6 +2038,18 @@ fn make_string() -> JsValue {
     JsValue::PlainObject(Rc::new(RefCell::new(props)))
 }
 
+// ── RegExp ────────────────────────────────────────────────────────────────────
+
+/// Build the `RegExp` constructor.
+fn make_regexp() -> JsValue {
+    let mut props: HashMap<String, JsValue> = HashMap::new();
+
+    // Callable: new RegExp(pattern, flags)
+    props.insert("__call__".into(), native(|args| regexp_construct(&args)));
+
+    JsValue::PlainObject(Rc::new(RefCell::new(props)))
+}
+
 // ── install_globals ──────────────────────────────────────────────────────────
 
 /// Pre-populate `globals` with all ECMAScript built-in names.
@@ -2059,6 +2074,7 @@ pub fn install_globals(globals: &mut HashMap<String, JsValue>) {
     globals.insert("Set".into(), make_set_builtin());
     globals.insert("WeakMap".into(), make_weak_map_builtin());
     globals.insert("WeakSet".into(), make_weak_set_builtin());
+    globals.insert("RegExp".into(), make_regexp());
 
     // ── Error constructors ────────────────────────────────────────────────
     install_error_constructors(globals);
@@ -2186,6 +2202,7 @@ mod tests {
         assert!(globals.contains_key("Set"));
         assert!(globals.contains_key("WeakMap"));
         assert!(globals.contains_key("WeakSet"));
+        assert!(globals.contains_key("RegExp"));
         assert!(globals.contains_key("globalThis"));
     }
 

--- a/crates/stator_core/src/builtins/mod.rs
+++ b/crates/stator_core/src/builtins/mod.rs
@@ -37,6 +37,8 @@ pub mod promise;
 pub mod proxy;
 /// ECMAScript §28.1 `Reflect` built-in static methods.
 pub mod reflect;
+/// ECMAScript §22.2 `RegExp` built-in constructor and prototype methods.
+pub mod regexp;
 /// ECMAScript §24.2 `Set` built-in — insertion-ordered unique-value collection.
 pub mod set;
 /// ECMAScript §22.1 `String` built-in static methods and prototype equivalents.

--- a/crates/stator_core/src/builtins/regexp.rs
+++ b/crates/stator_core/src/builtins/regexp.rs
@@ -1,0 +1,491 @@
+//! ECMAScript §22.2 `RegExp` built-in constructor and prototype methods.
+//!
+//! This module provides the functions wired into [`super::install_globals`] so
+//! that JavaScript code can construct `RegExp` objects and call their prototype
+//! methods (`test`, `exec`, `toString`, and the `Symbol.match/replace/search/
+//! split/matchAll` protocols).
+//!
+//! The heavy lifting is done by [`JsRegExp`] in
+//! [`crate::objects::regexp`]; this module converts between [`JsValue`] and
+//! the Rust-level API.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use crate::error::StatorResult;
+use crate::objects::regexp::{JsRegExp, RegExpFlags, SymbolMatchResult};
+use crate::objects::value::{JsValue, NativeIterator};
+
+/// Create a new [`JsRegExp`] from positional `JsValue` arguments.
+///
+/// `args[0]` — pattern (string), `args[1]` — flags (string, default `""`).
+/// Returns a `JsValue::PlainObject` with the regexp stored under `__regexp__`
+/// together with accessor properties (`source`, `flags`, `global`, etc.) and
+/// prototype methods.
+pub fn regexp_construct(args: &[JsValue]) -> StatorResult<JsValue> {
+    let pattern = match args.first() {
+        Some(v) => v.to_js_string()?,
+        None => String::new(),
+    };
+    let flags = match args.get(1) {
+        Some(JsValue::Undefined) | None => String::new(),
+        Some(v) => v.to_js_string()?,
+    };
+    let re = JsRegExp::new(&pattern, &flags)?;
+    Ok(wrap_regexp(re))
+}
+
+/// Convert a [`JsRegExp`] into a `JsValue::PlainObject` exposing all
+/// ECMAScript `RegExp.prototype` properties and methods.
+pub fn wrap_regexp(re: JsRegExp) -> JsValue {
+    let re = Rc::new(re);
+    let mut props: HashMap<String, JsValue> = HashMap::new();
+
+    // ── Read-only accessors ─────────────────────────────────────────────
+    props.insert("source".into(), JsValue::String(re.pattern().to_string()));
+    props.insert(
+        "flags".into(),
+        JsValue::String(re.flags().to_flags_string()),
+    );
+    props.insert(
+        "global".into(),
+        JsValue::Boolean(re.flags().contains(RegExpFlags::GLOBAL)),
+    );
+    props.insert(
+        "ignoreCase".into(),
+        JsValue::Boolean(re.flags().contains(RegExpFlags::IGNORE_CASE)),
+    );
+    props.insert(
+        "multiline".into(),
+        JsValue::Boolean(re.flags().contains(RegExpFlags::MULTILINE)),
+    );
+    props.insert(
+        "dotAll".into(),
+        JsValue::Boolean(re.flags().contains(RegExpFlags::DOT_ALL)),
+    );
+    props.insert(
+        "unicode".into(),
+        JsValue::Boolean(re.flags().contains(RegExpFlags::UNICODE)),
+    );
+    props.insert(
+        "unicodeSets".into(),
+        JsValue::Boolean(re.flags().contains(RegExpFlags::UNICODE_SETS)),
+    );
+    props.insert(
+        "sticky".into(),
+        JsValue::Boolean(re.flags().contains(RegExpFlags::STICKY)),
+    );
+    props.insert(
+        "hasIndices".into(),
+        JsValue::Boolean(re.flags().contains(RegExpFlags::HAS_INDICES)),
+    );
+
+    // ── lastIndex (read/write) ──────────────────────────────────────────
+    props.insert("lastIndex".into(), JsValue::Smi(re.last_index() as i32));
+
+    // ── Prototype methods ───────────────────────────────────────────────
+
+    // test(string)
+    let re_test = Rc::clone(&re);
+    props.insert(
+        "test".into(),
+        JsValue::NativeFunction(Rc::new(move |args: Vec<JsValue>| {
+            let input = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+            Ok(JsValue::Boolean(re_test.test(&input)))
+        })),
+    );
+
+    // exec(string)
+    let re_exec = Rc::clone(&re);
+    props.insert(
+        "exec".into(),
+        JsValue::NativeFunction(Rc::new(move |args: Vec<JsValue>| {
+            let input = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+            match re_exec.exec(&input) {
+                Some(m) => Ok(match_to_js(&m)),
+                None => Ok(JsValue::Null),
+            }
+        })),
+    );
+
+    // toString()
+    let re_str = Rc::clone(&re);
+    props.insert(
+        "toString".into(),
+        JsValue::NativeFunction(Rc::new(move |_args: Vec<JsValue>| {
+            Ok(JsValue::String(re_str.to_string()))
+        })),
+    );
+
+    // [Symbol.match](string)
+    let re_match = Rc::clone(&re);
+    props.insert(
+        "__symbol_match__".into(),
+        JsValue::NativeFunction(Rc::new(move |args: Vec<JsValue>| {
+            let input = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+            match re_match.symbol_match(&input) {
+                None => Ok(JsValue::Null),
+                Some(SymbolMatchResult::Single(m)) => Ok(match_to_js(&m)),
+                Some(SymbolMatchResult::All(v)) => {
+                    let arr: Vec<JsValue> = v.into_iter().map(JsValue::String).collect();
+                    Ok(JsValue::Array(Rc::new(arr)))
+                }
+            }
+        })),
+    );
+
+    // [Symbol.replace](string, replacement)
+    let re_replace = Rc::clone(&re);
+    props.insert(
+        "__symbol_replace__".into(),
+        JsValue::NativeFunction(Rc::new(move |args: Vec<JsValue>| {
+            let input = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+            let replacement = args.get(1).unwrap_or(&JsValue::Undefined).to_js_string()?;
+            Ok(JsValue::String(
+                re_replace.symbol_replace(&input, &replacement),
+            ))
+        })),
+    );
+
+    // [Symbol.search](string)
+    let re_search = Rc::clone(&re);
+    props.insert(
+        "__symbol_search__".into(),
+        JsValue::NativeFunction(Rc::new(move |args: Vec<JsValue>| {
+            let input = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+            let idx = re_search.symbol_search(&input);
+            Ok(if idx >= 0 {
+                JsValue::Smi(idx as i32)
+            } else {
+                JsValue::Smi(-1)
+            })
+        })),
+    );
+
+    // [Symbol.split](string[, limit])
+    let re_split = Rc::clone(&re);
+    props.insert(
+        "__symbol_split__".into(),
+        JsValue::NativeFunction(Rc::new(move |args: Vec<JsValue>| {
+            let input = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+            let limit = match args.get(1) {
+                Some(JsValue::Undefined) | None => None,
+                Some(v) => Some(v.to_number()? as usize),
+            };
+            let parts = re_split.symbol_split(&input, limit);
+            let arr: Vec<JsValue> = parts.into_iter().map(JsValue::String).collect();
+            Ok(JsValue::Array(Rc::new(arr)))
+        })),
+    );
+
+    // [Symbol.matchAll](string)
+    let re_match_all = Rc::clone(&re);
+    props.insert(
+        "__symbol_match_all__".into(),
+        JsValue::NativeFunction(Rc::new(move |args: Vec<JsValue>| {
+            let input = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+            let matches = re_match_all.symbol_match_all(&input);
+            let items: Vec<JsValue> = matches.iter().map(match_to_js).collect();
+            Ok(JsValue::Iterator(NativeIterator::from_items(items)))
+        })),
+    );
+
+    // Sentinel so the interpreter can identify this PlainObject as a RegExp.
+    props.insert("__is_regexp__".into(), JsValue::Boolean(true));
+
+    JsValue::PlainObject(Rc::new(RefCell::new(props)))
+}
+
+/// Convert a [`RegExpMatch`] into a `JsValue::PlainObject` matching the
+/// ECMAScript `RegExpExecResult` shape:
+///
+/// * Index `0` → full match (via numeric string key)
+/// * Index `1..` → capture groups
+/// * `index` → byte offset
+/// * `input` → original input string
+/// * `groups` → named groups object (or `undefined`)
+/// * `indices` → `{ 0: [s,e], 1: [s,e], …, groups: {…} }` when `/d` flag
+fn match_to_js(m: &crate::objects::regexp::RegExpMatch) -> JsValue {
+    let mut props: HashMap<String, JsValue> = HashMap::new();
+
+    // [0] = full match
+    props.insert("0".into(), JsValue::String(m.matched.clone()));
+    // [1..] = captures
+    for (i, cap) in m.captures.iter().enumerate() {
+        let key = (i + 1).to_string();
+        props.insert(
+            key,
+            match cap {
+                Some(s) => JsValue::String(s.clone()),
+                None => JsValue::Undefined,
+            },
+        );
+    }
+    props.insert("index".into(), JsValue::Smi(m.index as i32));
+    props.insert("input".into(), JsValue::String(m.input.clone()));
+
+    // groups
+    if m.named_groups.is_empty() {
+        props.insert("groups".into(), JsValue::Undefined);
+    } else {
+        let groups: HashMap<String, JsValue> = m
+            .named_groups
+            .iter()
+            .map(|(k, v)| (k.clone(), JsValue::String(v.clone())))
+            .collect();
+        props.insert(
+            "groups".into(),
+            JsValue::PlainObject(Rc::new(RefCell::new(groups))),
+        );
+    }
+
+    // indices (only present when /d flag was used)
+    if let Some(ref idx) = m.indices {
+        let mut idx_props: HashMap<String, JsValue> = HashMap::new();
+        for (i, pair) in idx.pairs.iter().enumerate() {
+            let val = match pair {
+                Some((s, e)) => JsValue::Array(Rc::new(vec![
+                    JsValue::Smi(*s as i32),
+                    JsValue::Smi(*e as i32),
+                ])),
+                None => JsValue::Undefined,
+            };
+            idx_props.insert(i.to_string(), val);
+        }
+        if !idx.groups.is_empty() {
+            let g: HashMap<String, JsValue> = idx
+                .groups
+                .iter()
+                .map(|(k, (s, e))| {
+                    (
+                        k.clone(),
+                        JsValue::Array(Rc::new(vec![
+                            JsValue::Smi(*s as i32),
+                            JsValue::Smi(*e as i32),
+                        ])),
+                    )
+                })
+                .collect();
+            idx_props.insert(
+                "groups".into(),
+                JsValue::PlainObject(Rc::new(RefCell::new(g))),
+            );
+        }
+        props.insert(
+            "indices".into(),
+            JsValue::PlainObject(Rc::new(RefCell::new(idx_props))),
+        );
+    }
+
+    // length = 1 + captures.len() (spec compatibility)
+    props.insert("length".into(), JsValue::Smi((1 + m.captures.len()) as i32));
+
+    JsValue::PlainObject(Rc::new(RefCell::new(props)))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: extract a string property from a PlainObject JsValue.
+    fn get_str(obj: &JsValue, key: &str) -> Option<String> {
+        if let JsValue::PlainObject(map) = obj {
+            match map.borrow().get(key)? {
+                JsValue::String(s) => Some(s.clone()),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Helper: extract a bool property from a PlainObject JsValue.
+    fn get_bool(obj: &JsValue, key: &str) -> Option<bool> {
+        if let JsValue::PlainObject(map) = obj {
+            match map.borrow().get(key)? {
+                JsValue::Boolean(b) => Some(*b),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Helper: extract an i32 property.
+    fn get_smi(obj: &JsValue, key: &str) -> Option<i32> {
+        if let JsValue::PlainObject(map) = obj {
+            match map.borrow().get(key)? {
+                JsValue::Smi(n) => Some(*n),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    #[test]
+    fn test_regexp_construct_basic() {
+        let re = regexp_construct(&[JsValue::String(r"\d+".into()), JsValue::String("g".into())])
+            .unwrap();
+        assert_eq!(get_str(&re, "source").as_deref(), Some(r"\d+"));
+        assert_eq!(get_str(&re, "flags").as_deref(), Some("g"));
+        assert_eq!(get_bool(&re, "global"), Some(true));
+        assert_eq!(get_bool(&re, "sticky"), Some(false));
+    }
+
+    #[test]
+    fn test_regexp_construct_defaults() {
+        let re = regexp_construct(&[]).unwrap();
+        assert_eq!(get_str(&re, "source").as_deref(), Some(""));
+        assert_eq!(get_str(&re, "flags").as_deref(), Some(""));
+    }
+
+    #[test]
+    fn test_exec_returns_match_object() {
+        let re = regexp_construct(&[JsValue::String(r"(\d+)".into()), JsValue::String("".into())])
+            .unwrap();
+        if let JsValue::PlainObject(map) = &re {
+            let exec_fn = map.borrow().get("exec").cloned().unwrap();
+            if let JsValue::NativeFunction(f) = exec_fn {
+                let result = f(vec![JsValue::String("price 42 dollars".into())]).unwrap();
+                assert_eq!(get_str(&result, "0").as_deref(), Some("42"));
+                assert_eq!(get_str(&result, "1").as_deref(), Some("42"));
+                assert_eq!(get_smi(&result, "index"), Some(6));
+            } else {
+                panic!("exec should be NativeFunction");
+            }
+        }
+    }
+
+    #[test]
+    fn test_exec_named_groups() {
+        let re = regexp_construct(&[
+            JsValue::String(r"(?<year>\d{4})-(?<month>\d{2})".into()),
+            JsValue::String("u".into()),
+        ])
+        .unwrap();
+        if let JsValue::PlainObject(map) = &re {
+            let exec_fn = map.borrow().get("exec").cloned().unwrap();
+            if let JsValue::NativeFunction(f) = exec_fn {
+                let result = f(vec![JsValue::String("2024-07".into())]).unwrap();
+                assert_eq!(get_str(&result, "0").as_deref(), Some("2024-07"));
+                // Check groups object
+                if let JsValue::PlainObject(groups_map) = &result {
+                    let groups = groups_map.borrow().get("groups").cloned();
+                    if let Some(JsValue::PlainObject(g)) = groups {
+                        assert_eq!(
+                            g.borrow().get("year"),
+                            Some(&JsValue::String("2024".into()))
+                        );
+                        assert_eq!(g.borrow().get("month"), Some(&JsValue::String("07".into())));
+                    } else {
+                        panic!("groups should be PlainObject");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_exec_with_indices() {
+        let re = regexp_construct(&[
+            JsValue::String(r"(\d+)".into()),
+            JsValue::String("d".into()),
+        ])
+        .unwrap();
+        if let JsValue::PlainObject(map) = &re {
+            let exec_fn = map.borrow().get("exec").cloned().unwrap();
+            if let JsValue::NativeFunction(f) = exec_fn {
+                let result = f(vec![JsValue::String("abc 42 end".into())]).unwrap();
+                assert_eq!(get_str(&result, "0").as_deref(), Some("42"));
+                // Check indices
+                if let JsValue::PlainObject(result_map) = &result {
+                    let indices = result_map.borrow().get("indices").cloned();
+                    assert!(indices.is_some(), "indices should be present with /d flag");
+                    if let Some(JsValue::PlainObject(idx)) = indices {
+                        // indices[0] = [4, 6]
+                        let idx0 = idx.borrow().get("0").cloned();
+                        if let Some(JsValue::Array(arr)) = idx0 {
+                            assert_eq!(arr[0], JsValue::Smi(4));
+                            assert_eq!(arr[1], JsValue::Smi(6));
+                        } else {
+                            panic!("indices[0] should be an array");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_test_method() {
+        let re = regexp_construct(&[JsValue::String(r"\d+".into()), JsValue::String("".into())])
+            .unwrap();
+        if let JsValue::PlainObject(map) = &re {
+            let test_fn = map.borrow().get("test").cloned().unwrap();
+            if let JsValue::NativeFunction(f) = test_fn {
+                assert_eq!(
+                    f(vec![JsValue::String("hello 42".into())]).unwrap(),
+                    JsValue::Boolean(true)
+                );
+                assert_eq!(
+                    f(vec![JsValue::String("no digits".into())]).unwrap(),
+                    JsValue::Boolean(false)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_to_string_method() {
+        let re = regexp_construct(&[JsValue::String("foo".into()), JsValue::String("gi".into())])
+            .unwrap();
+        if let JsValue::PlainObject(map) = &re {
+            let ts_fn = map.borrow().get("toString").cloned().unwrap();
+            if let JsValue::NativeFunction(f) = ts_fn {
+                assert_eq!(f(vec![]).unwrap(), JsValue::String("/foo/gi".into()));
+            }
+        }
+    }
+
+    #[test]
+    fn test_symbol_match_all_produces_iterator() {
+        let re = regexp_construct(&[JsValue::String(r"\d+".into()), JsValue::String("g".into())])
+            .unwrap();
+        if let JsValue::PlainObject(map) = &re {
+            let ma_fn = map.borrow().get("__symbol_match_all__").cloned().unwrap();
+            if let JsValue::NativeFunction(f) = ma_fn {
+                let result = f(vec![JsValue::String("a1 b22 c333".into())]).unwrap();
+                if let JsValue::Iterator(iter) = result {
+                    let first = iter.borrow_mut().next_item();
+                    assert!(first.is_some());
+                    if let Some(JsValue::PlainObject(m)) = first {
+                        assert_eq!(m.borrow().get("0"), Some(&JsValue::String("1".into())));
+                    }
+                } else {
+                    panic!("expected Iterator");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_flag_accessors() {
+        let re = regexp_construct(&[
+            JsValue::String("a".into()),
+            JsValue::String("gimsdy".into()),
+        ])
+        .unwrap();
+        assert_eq!(get_bool(&re, "global"), Some(true));
+        assert_eq!(get_bool(&re, "ignoreCase"), Some(true));
+        assert_eq!(get_bool(&re, "multiline"), Some(true));
+        assert_eq!(get_bool(&re, "dotAll"), Some(true));
+        assert_eq!(get_bool(&re, "sticky"), Some(true));
+        assert_eq!(get_bool(&re, "hasIndices"), Some(true));
+        assert_eq!(get_bool(&re, "unicode"), Some(false));
+        assert_eq!(get_bool(&re, "unicodeSets"), Some(false));
+    }
+}

--- a/crates/stator_core/src/builtins/symbol.rs
+++ b/crates/stator_core/src/builtins/symbol.rs
@@ -48,6 +48,8 @@ pub const SYMBOL_SPLIT: u64 = 10;
 pub const SYMBOL_UNSCOPABLES: u64 = 11;
 /// `Symbol.asyncIterator` — used by `for await..of`.
 pub const SYMBOL_ASYNC_ITERATOR: u64 = 12;
+/// `Symbol.matchAll` — customises `String.prototype.matchAll`.
+pub const SYMBOL_MATCH_ALL: u64 = 13;
 
 /// First ID available for user-created symbols (everything below is reserved).
 const FIRST_USER_SYMBOL_ID: u64 = 100;
@@ -107,6 +109,8 @@ impl SymbolRegistry {
             .insert(SYMBOL_UNSCOPABLES, Some("Symbol.unscopables".into()));
         reg.descriptions
             .insert(SYMBOL_ASYNC_ITERATOR, Some("Symbol.asyncIterator".into()));
+        reg.descriptions
+            .insert(SYMBOL_MATCH_ALL, Some("Symbol.matchAll".into()));
         reg
     }
 }

--- a/crates/stator_core/src/objects/regexp.rs
+++ b/crates/stator_core/src/objects/regexp.rs
@@ -157,6 +157,7 @@ impl RegExpFlags {
 ///   starts.
 /// * `input` is the original input string.
 /// * `named_groups` contains any named capture group values keyed by name.
+/// * `indices` is populated when the `d` (hasIndices) flag is set.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RegExpMatch {
     /// The full matched substring.
@@ -169,6 +170,25 @@ pub struct RegExpMatch {
     pub index: usize,
     /// The input string against which the pattern was matched.
     pub input: String,
+    /// Match indices for the `d` flag (`[start, end]` pairs).
+    ///
+    /// The first element is the full match range; subsequent elements are
+    /// the capture group ranges (`None` for groups that did not participate).
+    /// Only populated when [`RegExpFlags::HAS_INDICES`] is set.
+    pub indices: Option<MatchIndices>,
+}
+
+/// Byte-offset index pairs for the `/d` (hasIndices) flag.
+///
+/// Each element is `(start, end)` as a byte-offset pair into the input string.
+/// The first element corresponds to the full match; subsequent elements are the
+/// capture groups (with `None` for groups that did not participate).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatchIndices {
+    /// `[start, end]` pairs: index 0 = full match, 1.. = capture groups.
+    pub pairs: Vec<Option<(usize, usize)>>,
+    /// Named group indices keyed by group name.
+    pub groups: HashMap<String, (usize, usize)>,
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -333,7 +353,11 @@ impl JsRegExp {
                 if is_stateful {
                     self.last_index.set(mat.end());
                 }
-                Some(build_match(input, &mat))
+                Some(build_match(
+                    input,
+                    &mat,
+                    self.flags.contains(RegExpFlags::HAS_INDICES),
+                ))
             }
         }
     }
@@ -443,7 +467,7 @@ impl JsRegExp {
             match m {
                 None => break,
                 Some(mat) => {
-                    let rm = build_match(input, &mat);
+                    let rm = build_match(input, &mat, false);
                     // Append the portion of input before this match.
                     result.push_str(&input[last_end..rm.index]);
                     // Apply replacement.
@@ -516,6 +540,39 @@ impl JsRegExp {
         }
         parts
     }
+
+    /// ECMAScript `RegExp.prototype[Symbol.matchAll](string)`.
+    ///
+    /// Returns all successive matches as a `Vec<RegExpMatch>`, producing the
+    /// same kind of result objects that [`Self::exec`] would for each match.
+    /// This is the underlying implementation for `String.prototype.matchAll`.
+    pub fn symbol_match_all(&self, input: &str) -> Vec<RegExpMatch> {
+        let has_indices = self.flags.contains(RegExpFlags::HAS_INDICES);
+        let mut results = Vec::new();
+        let mut start = 0_usize;
+        loop {
+            if start > input.len() {
+                break;
+            }
+            let m = if self.flags.contains(RegExpFlags::STICKY) {
+                self.compiled
+                    .find_from(input, start)
+                    .next()
+                    .filter(|m| m.start() == start)
+            } else {
+                self.compiled.find_from(input, start).next()
+            };
+            match m {
+                None => break,
+                Some(mat) => {
+                    let end = mat.end();
+                    results.push(build_match(input, &mat, has_indices));
+                    start = if end > start { end } else { start + 1 };
+                }
+            }
+        }
+        results
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -556,7 +613,10 @@ fn build_regress_flags(f: RegExpFlags) -> RegressFlags {
 }
 
 /// Converts a [`regress::Match`] into a [`RegExpMatch`].
-fn build_match(input: &str, mat: &regress::Match) -> RegExpMatch {
+///
+/// When `has_indices` is `true` the [`MatchIndices`] field is populated with
+/// byte-offset pairs for the full match and each capture group.
+fn build_match(input: &str, mat: &regress::Match, has_indices: bool) -> RegExpMatch {
     let matched = input[mat.range()].to_string();
     let index = mat.start();
 
@@ -571,12 +631,28 @@ fn build_match(input: &str, mat: &regress::Match) -> RegExpMatch {
         .filter_map(|(name, range)| range.map(|r| (name.to_string(), input[r].to_string())))
         .collect();
 
+    let indices = if has_indices {
+        let mut pairs = Vec::with_capacity(1 + mat.captures.len());
+        pairs.push(Some((mat.start(), mat.end())));
+        for cap in &mat.captures {
+            pairs.push(cap.as_ref().map(|r| (r.start, r.end)));
+        }
+        let groups: HashMap<String, (usize, usize)> = mat
+            .named_groups()
+            .filter_map(|(name, range)| range.map(|r| (name.to_string(), (r.start, r.end))))
+            .collect();
+        Some(MatchIndices { pairs, groups })
+    } else {
+        None
+    };
+
     RegExpMatch {
         matched,
         captures,
         named_groups,
         index,
         input: input.to_string(),
+        indices,
     }
 }
 


### PR DESCRIPTION
Closes #291

## Summary

Implements the full RegExp built-in API surface for ECMAScript spec compliance, building on the existing regress crate backend and JsRegExp object model.

### Changes

- **New builtins/regexp.rs**: RegExp constructor and all prototype methods (test, exec, toString) plus Symbol protocol methods (Symbol.match, Symbol.replace, Symbol.search, Symbol.split, Symbol.matchAll)
- **Match indices (/d flag)**: RegExpMatch now carries MatchIndices with byte-offset pairs for the full match and each capture group, exposed as match.indices
- **Named capture groups**: Exposed via match.groups object on exec results
- **Symbol.matchAll**: New well-known symbol + symbol_match_all() method returning a RegExpStringIterator
- **All flag accessors**: global, ignoreCase, multiline, dotAll, unicode, unicodeSets, sticky, hasIndices, source, flags
- **Wired into install_globals**: RegExp constructor available in the global environment

### Testing

All 2294 workspace tests pass (2 pre-existing turbofan failures excluded).
