### PR TITLE
feat: Map/Set iteration protocol (closes #296)

### DIFF
--- a/crates/stator_core/src/builtins/install_globals.rs
+++ b/crates/stator_core/src/builtins/install_globals.rs
@@ -41,8 +41,8 @@ use crate::builtins::iterator::{
     iterator_to_array,
 };
 use crate::builtins::map::{
-    map_clear, map_delete, map_entries, map_from_iterable, map_get, map_has, map_keys, map_new,
-    map_set, map_size, map_values,
+    MapIteratorKind, map_clear, map_create_iterator, map_delete, map_entries, map_from_iterable,
+    map_get, map_has, map_new, map_set, map_size,
 };
 use crate::builtins::math::{
     MATH_E, MATH_LN2, MATH_LN10, MATH_LOG2E, MATH_LOG10E, MATH_PI, MATH_SQRT1_2, MATH_SQRT2,
@@ -54,8 +54,8 @@ use crate::builtins::math::{
 };
 use crate::builtins::regexp::regexp_construct;
 use crate::builtins::set::{
-    set_add, set_clear, set_delete, set_entries, set_from_iterable, set_has, set_keys, set_new,
-    set_size, set_values,
+    SetIteratorKind, set_add, set_clear, set_create_iterator, set_delete, set_from_iterable,
+    set_has, set_new, set_size, set_values,
 };
 use crate::builtins::string::{
     string_anchor, string_at, string_big, string_blink, string_bold, string_char_at,
@@ -81,7 +81,7 @@ use crate::builtins::weak_map::{
 use crate::builtins::weak_ref::{weak_ref_deref, weak_ref_new};
 use crate::builtins::weak_set::{weak_set_add, weak_set_delete, weak_set_has, weak_set_new};
 use crate::error::{StatorError, StatorResult};
-use crate::objects::value::{JsValue, NativeIterator};
+use crate::objects::value::JsValue;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -2363,8 +2363,7 @@ fn make_map_builtin() -> JsValue {
                 obj.insert(
                     "keys".into(),
                     native(move |_| {
-                        let keys = map_keys(&inner.borrow());
-                        Ok(JsValue::Iterator(NativeIterator::from_items(keys)))
+                        Ok(map_create_iterator(&inner.borrow(), MapIteratorKind::Keys))
                     }),
                 );
             }
@@ -2374,8 +2373,10 @@ fn make_map_builtin() -> JsValue {
                 obj.insert(
                     "values".into(),
                     native(move |_| {
-                        let vals = map_values(&inner.borrow());
-                        Ok(JsValue::Iterator(NativeIterator::from_items(vals)))
+                        Ok(map_create_iterator(
+                            &inner.borrow(),
+                            MapIteratorKind::Values,
+                        ))
                     }),
                 );
             }
@@ -2385,12 +2386,23 @@ fn make_map_builtin() -> JsValue {
                 obj.insert(
                     "entries".into(),
                     native(move |_| {
-                        let entries = map_entries(&inner.borrow());
-                        let items: Vec<JsValue> = entries
-                            .into_iter()
-                            .map(|(k, v)| JsValue::Array(Rc::new(vec![k, v])))
-                            .collect();
-                        Ok(JsValue::Iterator(NativeIterator::from_items(items)))
+                        Ok(map_create_iterator(
+                            &inner.borrow(),
+                            MapIteratorKind::Entries,
+                        ))
+                    }),
+                );
+            }
+            // [Symbol.iterator]() — same as entries() per §24.1.3.13
+            {
+                let inner = Rc::clone(&inner);
+                obj.insert(
+                    "@@iterator".into(),
+                    native(move |_| {
+                        Ok(map_create_iterator(
+                            &inner.borrow(),
+                            MapIteratorKind::Entries,
+                        ))
                     }),
                 );
             }
@@ -2499,8 +2511,7 @@ fn make_set_builtin() -> JsValue {
                 obj.insert(
                     "keys".into(),
                     native(move |_| {
-                        let vals = set_keys(&inner.borrow());
-                        Ok(JsValue::Iterator(NativeIterator::from_items(vals)))
+                        Ok(set_create_iterator(&inner.borrow(), SetIteratorKind::Keys))
                     }),
                 );
             }
@@ -2510,8 +2521,10 @@ fn make_set_builtin() -> JsValue {
                 obj.insert(
                     "values".into(),
                     native(move |_| {
-                        let vals = set_values(&inner.borrow());
-                        Ok(JsValue::Iterator(NativeIterator::from_items(vals)))
+                        Ok(set_create_iterator(
+                            &inner.borrow(),
+                            SetIteratorKind::Values,
+                        ))
                     }),
                 );
             }
@@ -2521,12 +2534,23 @@ fn make_set_builtin() -> JsValue {
                 obj.insert(
                     "entries".into(),
                     native(move |_| {
-                        let entries = set_entries(&inner.borrow());
-                        let items: Vec<JsValue> = entries
-                            .into_iter()
-                            .map(|(k, v)| JsValue::Array(Rc::new(vec![k, v])))
-                            .collect();
-                        Ok(JsValue::Iterator(NativeIterator::from_items(items)))
+                        Ok(set_create_iterator(
+                            &inner.borrow(),
+                            SetIteratorKind::Entries,
+                        ))
+                    }),
+                );
+            }
+            // [Symbol.iterator]() — same as values() per §24.2.3.11
+            {
+                let inner = Rc::clone(&inner);
+                obj.insert(
+                    "@@iterator".into(),
+                    native(move |_| {
+                        Ok(set_create_iterator(
+                            &inner.borrow(),
+                            SetIteratorKind::Values,
+                        ))
                     }),
                 );
             }

--- a/crates/stator_core/src/builtins/map.rs
+++ b/crates/stator_core/src/builtins/map.rs
@@ -14,9 +14,29 @@
 //!
 //! * ECMAScript 2025 Language Specification §24.1 — *The Map Objects*
 
-use crate::objects::value::JsValue;
+use std::rc::Rc;
+
+use crate::objects::value::{JsValue, NativeIterator};
 
 use super::util::same_value_zero;
+
+// ── MapIteratorKind ───────────────────────────────────────────────────────────
+
+/// The iteration kind for a `Map` iterator (ECMAScript §24.1.5.1).
+///
+/// Determines which component of each entry the iterator yields:
+/// - `Entries` → `[key, value]` arrays
+/// - `Keys` → keys only
+/// - `Values` → values only
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MapIteratorKind {
+    /// Yield `[key, value]` pairs as two-element arrays.
+    Entries,
+    /// Yield keys only.
+    Keys,
+    /// Yield values only.
+    Values,
+}
 
 // ── JsMap ─────────────────────────────────────────────────────────────────────
 
@@ -356,6 +376,57 @@ pub fn map_iter(map: &JsMap) -> Vec<(JsValue, JsValue)> {
     map_entries(map)
 }
 
+// ── map_create_iterator ──────────────────────────────────────────────────────
+
+/// Create a [`JsValue::Iterator`] from a `Map` with the given iteration kind
+/// (ECMAScript §24.1.5 `CreateMapIterator`).
+///
+/// - [`MapIteratorKind::Entries`] yields `[key, value]` arrays.
+/// - [`MapIteratorKind::Keys`] yields keys only.
+/// - [`MapIteratorKind::Values`] yields values only.
+///
+/// The iterator snapshots the current entries and yields them in insertion
+/// order.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::map::{map_new, map_set, map_create_iterator, MapIteratorKind};
+/// use stator_core::builtins::iterator::iterator_next;
+/// use stator_core::objects::value::JsValue;
+/// use std::rc::Rc;
+///
+/// let mut m = map_new();
+/// map_set(&mut m, JsValue::String("a".into()), JsValue::Smi(1));
+///
+/// let iter = map_create_iterator(&m, MapIteratorKind::Entries);
+/// let r = iterator_next(&iter).unwrap();
+/// assert_eq!(
+///     r.value,
+///     JsValue::Array(Rc::new(vec![JsValue::String("a".into()), JsValue::Smi(1)]))
+/// );
+///
+/// let iter = map_create_iterator(&m, MapIteratorKind::Keys);
+/// let r = iterator_next(&iter).unwrap();
+/// assert_eq!(r.value, JsValue::String("a".into()));
+///
+/// let iter = map_create_iterator(&m, MapIteratorKind::Values);
+/// let r = iterator_next(&iter).unwrap();
+/// assert_eq!(r.value, JsValue::Smi(1));
+/// ```
+pub fn map_create_iterator(map: &JsMap, kind: MapIteratorKind) -> JsValue {
+    let items: Vec<JsValue> = match kind {
+        MapIteratorKind::Entries => map
+            .entries
+            .iter()
+            .map(|(k, v)| JsValue::Array(Rc::new(vec![k.clone(), v.clone()])))
+            .collect(),
+        MapIteratorKind::Keys => map.entries.iter().map(|(k, _)| k.clone()).collect(),
+        MapIteratorKind::Values => map.entries.iter().map(|(_, v)| v.clone()).collect(),
+    };
+    JsValue::Iterator(NativeIterator::from_items(items))
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -559,5 +630,79 @@ mod tests {
         map_set(&mut m, JsValue::HeapNumber(0.0_f64), JsValue::Smi(7));
         assert!(map_has(&m, &JsValue::HeapNumber(-0.0_f64)));
         assert_eq!(map_size(&m), 1);
+    }
+
+    // ── map_create_iterator ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_map_create_iterator_entries() {
+        use crate::builtins::iterator::iterator_next;
+        let mut m = map_new();
+        map_set(&mut m, JsValue::Smi(1), JsValue::String("a".into()));
+        map_set(&mut m, JsValue::Smi(2), JsValue::String("b".into()));
+        let iter = map_create_iterator(&m, MapIteratorKind::Entries);
+        let r1 = iterator_next(&iter).unwrap();
+        assert_eq!(
+            r1.value,
+            JsValue::Array(Rc::new(vec![JsValue::Smi(1), JsValue::String("a".into())]))
+        );
+        let r2 = iterator_next(&iter).unwrap();
+        assert_eq!(
+            r2.value,
+            JsValue::Array(Rc::new(vec![JsValue::Smi(2), JsValue::String("b".into())]))
+        );
+        assert!(iterator_next(&iter).unwrap().done);
+    }
+
+    #[test]
+    fn test_map_create_iterator_keys() {
+        use crate::builtins::iterator::iterator_next;
+        let mut m = map_new();
+        map_set(&mut m, JsValue::Smi(1), JsValue::String("a".into()));
+        map_set(&mut m, JsValue::Smi(2), JsValue::String("b".into()));
+        let iter = map_create_iterator(&m, MapIteratorKind::Keys);
+        assert_eq!(iterator_next(&iter).unwrap().value, JsValue::Smi(1));
+        assert_eq!(iterator_next(&iter).unwrap().value, JsValue::Smi(2));
+        assert!(iterator_next(&iter).unwrap().done);
+    }
+
+    #[test]
+    fn test_map_create_iterator_values() {
+        use crate::builtins::iterator::iterator_next;
+        let mut m = map_new();
+        map_set(&mut m, JsValue::Smi(1), JsValue::String("a".into()));
+        map_set(&mut m, JsValue::Smi(2), JsValue::String("b".into()));
+        let iter = map_create_iterator(&m, MapIteratorKind::Values);
+        assert_eq!(
+            iterator_next(&iter).unwrap().value,
+            JsValue::String("a".into())
+        );
+        assert_eq!(
+            iterator_next(&iter).unwrap().value,
+            JsValue::String("b".into())
+        );
+        assert!(iterator_next(&iter).unwrap().done);
+    }
+
+    #[test]
+    fn test_map_create_iterator_empty() {
+        use crate::builtins::iterator::iterator_next;
+        let m = map_new();
+        let iter = map_create_iterator(&m, MapIteratorKind::Entries);
+        assert!(iterator_next(&iter).unwrap().done);
+    }
+
+    #[test]
+    fn test_map_create_iterator_insertion_order() {
+        use crate::builtins::iterator::iterator_next;
+        let mut m = map_new();
+        map_set(&mut m, JsValue::Smi(3), JsValue::Undefined);
+        map_set(&mut m, JsValue::Smi(1), JsValue::Undefined);
+        map_set(&mut m, JsValue::Smi(2), JsValue::Undefined);
+        let iter = map_create_iterator(&m, MapIteratorKind::Keys);
+        assert_eq!(iterator_next(&iter).unwrap().value, JsValue::Smi(3));
+        assert_eq!(iterator_next(&iter).unwrap().value, JsValue::Smi(1));
+        assert_eq!(iterator_next(&iter).unwrap().value, JsValue::Smi(2));
+        assert!(iterator_next(&iter).unwrap().done);
     }
 }

--- a/crates/stator_core/src/builtins/set.rs
+++ b/crates/stator_core/src/builtins/set.rs
@@ -14,9 +14,30 @@
 //!
 //! * ECMAScript 2025 Language Specification §24.2 — *The Set Objects*
 
-use crate::objects::value::JsValue;
+use std::rc::Rc;
+
+use crate::objects::value::{JsValue, NativeIterator};
 
 use super::util::same_value_zero;
+
+// ── SetIteratorKind ───────────────────────────────────────────────────────────
+
+/// The iteration kind for a `Set` iterator (ECMAScript §24.2.5.1).
+///
+/// Determines what the iterator yields:
+/// - `Values` → individual values
+/// - `Entries` → `[value, value]` pairs (matching `Map` entry format)
+/// - `Keys` → alias for `Values` (per spec, `Set.prototype.keys === Set.prototype.values`)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SetIteratorKind {
+    /// Yield individual values.
+    Values,
+    /// Yield `[value, value]` pairs (matching the Map entry format).
+    Entries,
+    /// Alias for `Values` — `Set.prototype.keys` is the same function as
+    /// `Set.prototype.values` per the ECMAScript specification.
+    Keys,
+}
 
 // ── JsSet ─────────────────────────────────────────────────────────────────────
 
@@ -309,6 +330,51 @@ pub fn set_iter(set: &JsSet) -> Vec<JsValue> {
     set_values(set)
 }
 
+// ── set_create_iterator ──────────────────────────────────────────────────────
+
+/// Create a [`JsValue::Iterator`] from a `Set` with the given iteration kind
+/// (ECMAScript §24.2.5 `CreateSetIterator`).
+///
+/// - [`SetIteratorKind::Values`] / [`SetIteratorKind::Keys`] yields values.
+/// - [`SetIteratorKind::Entries`] yields `[value, value]` arrays.
+///
+/// The iterator snapshots the current values and yields them in insertion
+/// order.
+///
+/// # Examples
+///
+/// ```
+/// use stator_core::builtins::set::{set_new, set_add, set_create_iterator, SetIteratorKind};
+/// use stator_core::builtins::iterator::iterator_next;
+/// use stator_core::objects::value::JsValue;
+/// use std::rc::Rc;
+///
+/// let mut s = set_new();
+/// set_add(&mut s, JsValue::Smi(1));
+///
+/// let iter = set_create_iterator(&s, SetIteratorKind::Values);
+/// let r = iterator_next(&iter).unwrap();
+/// assert_eq!(r.value, JsValue::Smi(1));
+///
+/// let iter = set_create_iterator(&s, SetIteratorKind::Entries);
+/// let r = iterator_next(&iter).unwrap();
+/// assert_eq!(
+///     r.value,
+///     JsValue::Array(Rc::new(vec![JsValue::Smi(1), JsValue::Smi(1)]))
+/// );
+/// ```
+pub fn set_create_iterator(set: &JsSet, kind: SetIteratorKind) -> JsValue {
+    let items: Vec<JsValue> = match kind {
+        SetIteratorKind::Values | SetIteratorKind::Keys => set.values.clone(),
+        SetIteratorKind::Entries => set
+            .values
+            .iter()
+            .map(|v| JsValue::Array(Rc::new(vec![v.clone(), v.clone()])))
+            .collect(),
+    };
+    JsValue::Iterator(NativeIterator::from_items(items))
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -470,5 +536,74 @@ mod tests {
         set_add(&mut s, JsValue::HeapNumber(0.0_f64));
         set_add(&mut s, JsValue::HeapNumber(-0.0_f64));
         assert_eq!(set_size(&s), 1);
+    }
+
+    // ── set_create_iterator ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_create_iterator_values() {
+        use crate::builtins::iterator::iterator_next;
+        let mut s = set_new();
+        set_add(&mut s, JsValue::Smi(10));
+        set_add(&mut s, JsValue::Smi(20));
+        let iter = set_create_iterator(&s, SetIteratorKind::Values);
+        assert_eq!(iterator_next(&iter).unwrap().value, JsValue::Smi(10));
+        assert_eq!(iterator_next(&iter).unwrap().value, JsValue::Smi(20));
+        assert!(iterator_next(&iter).unwrap().done);
+    }
+
+    #[test]
+    fn test_set_create_iterator_keys_same_as_values() {
+        use crate::builtins::iterator::iterator_next;
+        let mut s = set_new();
+        set_add(&mut s, JsValue::Smi(5));
+        let keys_iter = set_create_iterator(&s, SetIteratorKind::Keys);
+        let vals_iter = set_create_iterator(&s, SetIteratorKind::Values);
+        assert_eq!(
+            iterator_next(&keys_iter).unwrap().value,
+            iterator_next(&vals_iter).unwrap().value
+        );
+    }
+
+    #[test]
+    fn test_set_create_iterator_entries() {
+        use crate::builtins::iterator::iterator_next;
+        let mut s = set_new();
+        set_add(&mut s, JsValue::Smi(1));
+        set_add(&mut s, JsValue::Smi(2));
+        let iter = set_create_iterator(&s, SetIteratorKind::Entries);
+        let r1 = iterator_next(&iter).unwrap();
+        assert_eq!(
+            r1.value,
+            JsValue::Array(Rc::new(vec![JsValue::Smi(1), JsValue::Smi(1)]))
+        );
+        let r2 = iterator_next(&iter).unwrap();
+        assert_eq!(
+            r2.value,
+            JsValue::Array(Rc::new(vec![JsValue::Smi(2), JsValue::Smi(2)]))
+        );
+        assert!(iterator_next(&iter).unwrap().done);
+    }
+
+    #[test]
+    fn test_set_create_iterator_empty() {
+        use crate::builtins::iterator::iterator_next;
+        let s = set_new();
+        let iter = set_create_iterator(&s, SetIteratorKind::Values);
+        assert!(iterator_next(&iter).unwrap().done);
+    }
+
+    #[test]
+    fn test_set_create_iterator_insertion_order() {
+        use crate::builtins::iterator::iterator_next;
+        let mut s = set_new();
+        set_add(&mut s, JsValue::Smi(3));
+        set_add(&mut s, JsValue::Smi(1));
+        set_add(&mut s, JsValue::Smi(2));
+        let iter = set_create_iterator(&s, SetIteratorKind::Values);
+        assert_eq!(iterator_next(&iter).unwrap().value, JsValue::Smi(3));
+        assert_eq!(iterator_next(&iter).unwrap().value, JsValue::Smi(1));
+        assert_eq!(iterator_next(&iter).unwrap().value, JsValue::Smi(2));
+        assert!(iterator_next(&iter).unwrap().done);
     }
 }

--- a/crates/stator_core/src/interpreter/mod.rs
+++ b/crates/stator_core/src/interpreter/mod.rs
@@ -2495,6 +2495,19 @@ impl Interpreter {
                         JsValue::String(ref s) => JsValue::Iterator(NativeIterator::from_string(s)),
                         // Generators and existing iterators pass through unchanged.
                         JsValue::Generator(_) | JsValue::Iterator(_) => iterable,
+                        // PlainObject with @@iterator → call it to get the iterator.
+                        JsValue::PlainObject(ref map)
+                            if map.borrow().contains_key("@@iterator") =>
+                        {
+                            let iter_fn = map.borrow().get("@@iterator").cloned();
+                            if let Some(JsValue::NativeFunction(f)) = iter_fn {
+                                f(vec![])?
+                            } else {
+                                return Err(StatorError::TypeError(
+                                    "GetIterator: @@iterator is not a function".into(),
+                                ));
+                            }
+                        }
                         // PlainObject with a "length" property → array-like.
                         JsValue::PlainObject(ref map) if map.borrow().contains_key("length") => {
                             let items = plain_object_to_array_items(map);
@@ -2523,6 +2536,19 @@ impl Interpreter {
                         }
                         JsValue::String(ref s) => JsValue::Iterator(NativeIterator::from_string(s)),
                         JsValue::Generator(_) | JsValue::Iterator(_) => iterable,
+                        // PlainObject with @@iterator → call it to get the iterator.
+                        JsValue::PlainObject(ref map)
+                            if map.borrow().contains_key("@@iterator") =>
+                        {
+                            let iter_fn = map.borrow().get("@@iterator").cloned();
+                            if let Some(JsValue::NativeFunction(f)) = iter_fn {
+                                f(vec![])?
+                            } else {
+                                return Err(StatorError::TypeError(
+                                    "GetAsyncIterator: @@iterator is not a function".into(),
+                                ));
+                            }
+                        }
                         JsValue::PlainObject(ref map) if map.borrow().contains_key("length") => {
                             let items = plain_object_to_array_items(map);
                             JsValue::Iterator(NativeIterator::from_items(items))


### PR DESCRIPTION
## Summary

Implements Map/Set iteration protocol support:

- **MapIteratorKind** enum (Entries/Keys/Values) and \map_create_iterator()\ factory
- **SetIteratorKind** enum (Values/Entries/Keys) and \set_create_iterator()\ factory
- **@@iterator** on Map objects (returns entries iterator, per §24.1.3.13)
- **@@iterator** on Set objects (returns values iterator, per §24.2.3.11)
- **GetIterator opcode** updated to invoke \@@iterator\ on PlainObjects (enables \or-of\ on Map/Set)
- Comprehensive tests for all iterator kinds and insertion-order guarantees

Closes #296