### PR TITLE
feat: Error builtins spec compliance (closes #295)

### DIFF
--- a/crates/stator_core/src/builtins/error.rs
+++ b/crates/stator_core/src/builtins/error.rs
@@ -34,6 +34,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::error::{StatorError, StatorResult};
+use crate::objects::value::JsValue;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Stack-trace limit
@@ -243,6 +244,8 @@ impl ErrorKind {
 /// | `name` | [`JsError::name`] |
 /// | `message` | [`JsError::message`] |
 /// | `stack` | [`JsError::stack`] |
+/// | `cause` | [`JsError::cause`] (ES2022) |
+/// | `errors` | [`JsError::errors`] (`AggregateError` only) |
 #[derive(Debug, Clone, PartialEq)]
 pub struct JsError {
     /// The kind of this error (determines the `name` property).
@@ -253,6 +256,11 @@ pub struct JsError {
     pub stack: String,
     /// Inner errors for `AggregateError` (empty for all other kinds).
     pub errors: Vec<Rc<JsError>>,
+    /// The ES2022 `cause` property — the underlying reason for this error.
+    ///
+    /// Set when the constructor receives an options object with a `cause`
+    /// property, e.g. `new Error("msg", { cause: originalError })`.
+    pub cause: Option<JsValue>,
 }
 
 impl JsError {
@@ -278,6 +286,7 @@ impl JsError {
             message,
             stack,
             errors: Vec::new(),
+            cause: None,
         }
     }
 
@@ -302,6 +311,7 @@ impl JsError {
             message,
             stack,
             errors,
+            cause: None,
         }
     }
 
@@ -318,6 +328,31 @@ impl JsError {
     /// The ECMAScript `stack` property — the formatted stack trace.
     pub fn stack(&self) -> &str {
         &self.stack
+    }
+
+    /// The ES2022 `cause` property — the underlying error cause, if any.
+    ///
+    /// Returns `None` when the error was constructed without a `cause` option.
+    pub fn cause(&self) -> Option<&JsValue> {
+        self.cause.as_ref()
+    }
+
+    /// Builder: set the `cause` property on this error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use stator_core::builtins::error::{JsError, ErrorKind};
+    /// use stator_core::objects::value::JsValue;
+    ///
+    /// let inner = JsValue::String("disk full".to_string());
+    /// let e = JsError::new(ErrorKind::Error, "write failed".to_string())
+    ///     .with_cause(inner.clone());
+    /// assert_eq!(e.cause(), Some(&inner));
+    /// ```
+    pub fn with_cause(mut self, cause: JsValue) -> Self {
+        self.cause = Some(cause);
+        self
     }
 
     /// ECMAScript §20.5.8 `Error.prototype.toString()`.
@@ -643,5 +678,67 @@ mod tests {
             matches!(result, Err(crate::error::StatorError::RangeError(_))),
             "expected RangeError when call stack is full, got {result:?}"
         );
+    }
+
+    // ── cause property (ES2022) ──────────────────────────────────────────────
+
+    #[test]
+    fn test_error_cause_none_by_default() {
+        let e = JsError::new(ErrorKind::Error, "no cause".to_string());
+        assert!(e.cause().is_none());
+    }
+
+    #[test]
+    fn test_error_with_cause() {
+        let cause = JsValue::String("disk full".to_string());
+        let e =
+            JsError::new(ErrorKind::Error, "write failed".to_string()).with_cause(cause.clone());
+        assert_eq!(e.cause(), Some(&cause));
+    }
+
+    #[test]
+    fn test_error_cause_can_be_error_value() {
+        let inner = JsValue::Error(Rc::new(type_error_new("bad type".to_string())));
+        let outer = JsError::new(ErrorKind::Error, "wrapper".to_string()).with_cause(inner.clone());
+        assert_eq!(outer.cause(), Some(&inner));
+    }
+
+    #[test]
+    fn test_aggregate_error_cause_none_by_default() {
+        let agg = aggregate_error_new(vec![], "agg".to_string());
+        assert!(agg.cause().is_none());
+    }
+
+    #[test]
+    fn test_aggregate_error_with_cause() {
+        let cause = JsValue::Smi(42);
+        let mut agg = aggregate_error_new(vec![], "agg".to_string());
+        agg.cause = Some(cause.clone());
+        assert_eq!(agg.cause(), Some(&cause));
+    }
+
+    // ── name/message inheritance ─────────────────────────────────────────────
+
+    #[test]
+    fn test_all_error_kinds_have_correct_names() {
+        let kinds = [
+            (ErrorKind::Error, "Error"),
+            (ErrorKind::TypeError, "TypeError"),
+            (ErrorKind::RangeError, "RangeError"),
+            (ErrorKind::ReferenceError, "ReferenceError"),
+            (ErrorKind::SyntaxError, "SyntaxError"),
+            (ErrorKind::URIError, "URIError"),
+            (ErrorKind::EvalError, "EvalError"),
+            (ErrorKind::AggregateError, "AggregateError"),
+        ];
+        for (kind, expected_name) in kinds {
+            let e = JsError::new(kind, "test".to_string());
+            assert_eq!(e.name(), expected_name, "wrong name for {kind:?}");
+            assert_eq!(e.message(), "test");
+            assert!(
+                e.stack().starts_with(&format!("{expected_name}: test")),
+                "stack should start with error string for {kind:?}"
+            );
+        }
     }
 }

--- a/crates/stator_core/src/builtins/install_globals.rs
+++ b/crates/stator_core/src/builtins/install_globals.rs
@@ -91,13 +91,62 @@ fn native(f: impl Fn(Vec<JsValue>) -> StatorResult<JsValue> + 'static) -> JsValu
 }
 
 /// Build a NativeFunction that constructs a `JsValue::Error` of the given `ErrorKind`.
+///
+/// Supports the ES2022 options parameter: `new Error(message, { cause })`.
 fn make_error_constructor(kind: ErrorKind) -> JsValue {
     native(move |args| {
         let message = match args.first() {
             Some(JsValue::Undefined) | None => String::new(),
             Some(v) => v.to_js_string()?,
         };
-        Ok(JsValue::Error(Rc::new(JsError::new(kind, message))))
+        let mut err = JsError::new(kind, message);
+        // ES2022: extract `cause` from the optional second options argument.
+        err.cause = extract_cause(args.get(1));
+        Ok(JsValue::Error(Rc::new(err)))
+    })
+}
+
+/// Extract the `cause` value from an options argument, if present.
+fn extract_cause(options: Option<&JsValue>) -> Option<JsValue> {
+    if let Some(JsValue::PlainObject(map)) = options {
+        map.borrow().get("cause").cloned()
+    } else {
+        None
+    }
+}
+
+/// Build the `AggregateError` constructor.
+///
+/// Signature: `AggregateError(errors, message [, options])`.
+///
+/// The `errors` argument is consumed as an `Array`; the optional `options`
+/// object may contain a `cause` property (ES2022).
+fn make_aggregate_error_constructor() -> JsValue {
+    native(|args| {
+        // First arg: errors (iterable — we accept Array).
+        let errors_val = args.first().unwrap_or(&JsValue::Undefined);
+        let inner_errors: Vec<Rc<JsError>> = match errors_val {
+            JsValue::Array(arr) => arr
+                .iter()
+                .map(|v| match v {
+                    JsValue::Error(e) => Rc::clone(e),
+                    other => Rc::new(JsError::new(
+                        ErrorKind::Error,
+                        other.to_js_string().unwrap_or_default(),
+                    )),
+                })
+                .collect(),
+            _ => Vec::new(),
+        };
+        // Second arg: message.
+        let message = match args.get(1) {
+            Some(JsValue::Undefined) | None => String::new(),
+            Some(v) => v.to_js_string()?,
+        };
+        let mut err = JsError::new_aggregate(inner_errors, message);
+        // Third arg: optional options object with `cause`.
+        err.cause = extract_cause(args.get(2));
+        Ok(JsValue::Error(Rc::new(err)))
     })
 }
 
@@ -128,6 +177,7 @@ fn install_error_constructors(globals: &mut HashMap<String, JsValue>) {
         "EvalError".into(),
         make_error_constructor(ErrorKind::EvalError),
     );
+    globals.insert("AggregateError".into(), make_aggregate_error_constructor());
 }
 
 /// Convert an `f64` to the most compact `JsValue` representation.
@@ -4258,6 +4308,15 @@ mod tests {
         assert!(globals.contains_key("BigInt"));
         assert!(globals.contains_key("Function"));
         assert!(globals.contains_key("globalThis"));
+        // Error constructors
+        assert!(globals.contains_key("Error"));
+        assert!(globals.contains_key("TypeError"));
+        assert!(globals.contains_key("RangeError"));
+        assert!(globals.contains_key("ReferenceError"));
+        assert!(globals.contains_key("SyntaxError"));
+        assert!(globals.contains_key("URIError"));
+        assert!(globals.contains_key("EvalError"));
+        assert!(globals.contains_key("AggregateError"));
     }
 
     /// Verify that the `Math` object has the expected properties.
@@ -7563,5 +7622,112 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result, JsValue::Smi(777));
+    }
+
+    // ── Error spec-compliance e2e tests (issue #295) ─────────────────────
+
+    /// `new Error("msg").name` → "Error"
+    #[test]
+    fn e2e_error_name_property() {
+        let result = global_eval(r#"var e = new Error("msg"); e.name"#).unwrap();
+        assert_eq!(result, JsValue::String("Error".to_string()));
+    }
+
+    /// `new TypeError("msg").name` → "TypeError"
+    #[test]
+    fn e2e_type_error_name() {
+        let result = global_eval(r#"var e = new TypeError("msg"); e.name"#).unwrap();
+        assert_eq!(result, JsValue::String("TypeError".to_string()));
+    }
+
+    /// `new RangeError("msg").name` → "RangeError"
+    #[test]
+    fn e2e_range_error_name() {
+        let result = global_eval(r#"var e = new RangeError("msg"); e.name"#).unwrap();
+        assert_eq!(result, JsValue::String("RangeError".to_string()));
+    }
+
+    /// `new ReferenceError("msg").name` → "ReferenceError"
+    #[test]
+    fn e2e_reference_error_name() {
+        let result = global_eval(r#"var e = new ReferenceError("msg"); e.name"#).unwrap();
+        assert_eq!(result, JsValue::String("ReferenceError".to_string()));
+    }
+
+    /// `new SyntaxError("msg").name` → "SyntaxError"
+    #[test]
+    fn e2e_syntax_error_name() {
+        let result = global_eval(r#"var e = new SyntaxError("msg"); e.name"#).unwrap();
+        assert_eq!(result, JsValue::String("SyntaxError".to_string()));
+    }
+
+    /// `new URIError("msg").name` → "URIError"
+    #[test]
+    fn e2e_uri_error_name() {
+        let result = global_eval(r#"var e = new URIError("msg"); e.name"#).unwrap();
+        assert_eq!(result, JsValue::String("URIError".to_string()));
+    }
+
+    /// `new EvalError("msg").name` → "EvalError"
+    #[test]
+    fn e2e_eval_error_name() {
+        let result = global_eval(r#"var e = new EvalError("msg"); e.name"#).unwrap();
+        assert_eq!(result, JsValue::String("EvalError".to_string()));
+    }
+
+    /// `new Error("msg").message` → "msg"
+    #[test]
+    fn e2e_error_message_property() {
+        let result = global_eval(r#"var e = new Error("hello"); e.message"#).unwrap();
+        assert_eq!(result, JsValue::String("hello".to_string()));
+    }
+
+    /// `new Error("msg").stack` starts with "Error: msg"
+    #[test]
+    fn e2e_error_stack_property() {
+        let result = global_eval(r#"var e = new Error("msg"); e.stack"#).unwrap();
+        if let JsValue::String(s) = result {
+            assert!(
+                s.starts_with("Error: msg"),
+                "stack should start with error string: {s}"
+            );
+        } else {
+            panic!("expected String for .stack");
+        }
+    }
+
+    /// Error without cause: `.cause` → undefined
+    #[test]
+    fn e2e_error_cause_undefined_when_absent() {
+        let result = global_eval(r#"var e = new Error("msg"); e.cause"#).unwrap();
+        assert_eq!(result, JsValue::Undefined);
+    }
+
+    /// AggregateError constructor: `.name` → "AggregateError"
+    #[test]
+    fn e2e_aggregate_error_name() {
+        let result = global_eval(r#"var e = new AggregateError([], "msg"); e.name"#).unwrap();
+        assert_eq!(result, JsValue::String("AggregateError".to_string()));
+    }
+
+    /// AggregateError constructor: `.message` → "msg"
+    #[test]
+    fn e2e_aggregate_error_message() {
+        let result = global_eval(r#"var e = new AggregateError([], "msg"); e.message"#).unwrap();
+        assert_eq!(result, JsValue::String("msg".to_string()));
+    }
+
+    /// `new Error("msg").toString()` → "Error: msg"
+    #[test]
+    fn e2e_error_to_string() {
+        let result = global_eval(r#"var e = new Error("msg"); e.toString()"#).unwrap();
+        assert_eq!(result, JsValue::String("Error: msg".to_string()));
+    }
+
+    /// `new TypeError("").toString()` → "TypeError"
+    #[test]
+    fn e2e_type_error_to_string_empty_message() {
+        let result = global_eval(r#"var e = new TypeError(); e.toString()"#).unwrap();
+        assert_eq!(result, JsValue::String("TypeError".to_string()));
     }
 }

--- a/crates/stator_core/src/interpreter/mod.rs
+++ b/crates/stator_core/src/interpreter/mod.rs
@@ -4862,12 +4862,29 @@ fn proto_lookup(obj: &JsValue, key: &str) -> JsValue {
             _ => JsValue::Undefined,
         };
     }
-    // Handle JsValue::Error — expose name, message, stack properties.
+    // Handle JsValue::Error — expose name, message, stack, cause, errors properties.
     if let JsValue::Error(e) = obj {
+        let err = Rc::clone(e);
         return match key {
             "name" => JsValue::String(e.name().to_string()),
             "message" => JsValue::String(e.message().to_string()),
             "stack" => JsValue::String(e.stack().to_string()),
+            "cause" => e.cause().cloned().unwrap_or(JsValue::Undefined),
+            "errors" => {
+                if e.kind == crate::builtins::error::ErrorKind::AggregateError {
+                    JsValue::Array(Rc::new(
+                        e.errors
+                            .iter()
+                            .map(|ie| JsValue::Error(Rc::clone(ie)))
+                            .collect(),
+                    ))
+                } else {
+                    JsValue::Undefined
+                }
+            }
+            "toString" => JsValue::NativeFunction(Rc::new(move |_args| {
+                Ok(JsValue::String(err.to_error_string()))
+            })),
             _ => JsValue::Undefined,
         };
     }
@@ -10361,6 +10378,75 @@ mod tests {
         }
         // Unknown property returns undefined
         assert_eq!(proto_lookup(&err, "foo"), JsValue::Undefined);
+    }
+
+    /// Test that `proto_lookup` exposes `cause` property (ES2022).
+    #[test]
+    fn test_proto_lookup_error_cause_property() {
+        use crate::builtins::error::{ErrorKind, JsError};
+
+        // Error without cause returns undefined.
+        let err = JsValue::Error(Rc::new(JsError::new(
+            ErrorKind::Error,
+            "no cause".to_string(),
+        )));
+        assert_eq!(proto_lookup(&err, "cause"), JsValue::Undefined);
+
+        // Error with cause returns the cause value.
+        let cause = JsValue::String("original problem".to_string());
+        let err_with_cause = JsValue::Error(Rc::new(
+            JsError::new(ErrorKind::Error, "wrapper".to_string()).with_cause(cause.clone()),
+        ));
+        assert_eq!(proto_lookup(&err_with_cause, "cause"), cause);
+    }
+
+    /// Test that `proto_lookup` exposes `errors` property for `AggregateError`.
+    #[test]
+    fn test_proto_lookup_aggregate_error_errors_property() {
+        use crate::builtins::error::{ErrorKind, JsError};
+
+        let inner1 = Rc::new(JsError::new(ErrorKind::TypeError, "bad type".to_string()));
+        let inner2 = Rc::new(JsError::new(
+            ErrorKind::RangeError,
+            "out of range".to_string(),
+        ));
+        let agg = JsValue::Error(Rc::new(JsError::new_aggregate(
+            vec![inner1.clone(), inner2.clone()],
+            "multiple failures".to_string(),
+        )));
+
+        // errors property should be an Array of Error values.
+        if let JsValue::Array(arr) = proto_lookup(&agg, "errors") {
+            assert_eq!(arr.len(), 2);
+            assert!(matches!(&arr[0], JsValue::Error(e) if e.kind == ErrorKind::TypeError));
+            assert!(matches!(&arr[1], JsValue::Error(e) if e.kind == ErrorKind::RangeError));
+        } else {
+            panic!("expected Array for AggregateError.errors");
+        }
+
+        // Non-AggregateError should return undefined for errors.
+        let regular = JsValue::Error(Rc::new(JsError::new(
+            ErrorKind::Error,
+            "regular".to_string(),
+        )));
+        assert_eq!(proto_lookup(&regular, "errors"), JsValue::Undefined);
+    }
+
+    /// Test that `proto_lookup` exposes `toString` method on errors.
+    #[test]
+    fn test_proto_lookup_error_to_string_method() {
+        use crate::builtins::error::{ErrorKind, JsError};
+
+        let err = JsValue::Error(Rc::new(JsError::new(
+            ErrorKind::TypeError,
+            "bad value".to_string(),
+        )));
+        if let JsValue::NativeFunction(f) = proto_lookup(&err, "toString") {
+            let result = f(vec![]).unwrap();
+            assert_eq!(result, JsValue::String("TypeError: bad value".to_string()));
+        } else {
+            panic!("expected NativeFunction for toString");
+        }
     }
 
     // ── DeletePropertySloppy / DeletePropertyStrict ──────────────────────


### PR DESCRIPTION
## Summary

Implements issue #295: Phase 2 Error builtins spec compliance.

### Changes

- **ES2022 \cause\ property**: Added \cause: Option<JsValue>\ field to \JsError\ with \with_cause()\ builder and \cause()\ accessor. All error constructors now accept an optional options object \{ cause }\ as the second argument.

- **\AggregateError\ constructor**: Registered in globals with signature \AggregateError(errors, message [, options])\. Accepts an Array of errors and optional cause via options.

- **Property exposure**: The interpreter's property access for \JsValue::Error\ now exposes:
  - \
ame\ — error constructor name
  - \message\ — human-readable description  
  - \stack\ — formatted stack trace (non-standard, V8-compat)
  - \cause\ — ES2022 cause value (undefined when absent)
  - \rrors\ — Array of inner errors (AggregateError only)
  - \	oString()\ — \Error.prototype.toString()\ method

- **All 8 error types registered**: Error, TypeError, RangeError, ReferenceError, SyntaxError, URIError, EvalError, AggregateError

### Tests

23 new tests added (2911 total passing, 2 pre-existing turbofan failures):
- Unit tests for cause property, with_cause builder, all error kinds
- Interpreter tests for proto_lookup: cause, errors, toString
- E2E tests for all error constructor names, message, stack, cause, toString