### PR TITLE
feat: Intl namespace with basic formatters (closes #305)

### DIFF
--- a/crates/stator_core/src/builtins/install_globals.rs
+++ b/crates/stator_core/src/builtins/install_globals.rs
@@ -35,6 +35,11 @@ use crate::builtins::global::{
     global_encode_uri_component, global_escape, global_eval, global_is_finite, global_is_nan,
     global_parse_float, global_parse_int, global_unescape,
 };
+use crate::builtins::intl::{
+    collator_compare_js, date_time_format_js, display_names_of, list_format_js, locale_base_name,
+    locale_language, number_format_js, plural_rules_select_js, relative_time_format_js,
+    segmenter_segment,
+};
 use crate::builtins::iterator::{
     async_iterator_drop, async_iterator_every, async_iterator_filter, async_iterator_find,
     async_iterator_flat_map, async_iterator_for_each, async_iterator_from, async_iterator_map,
@@ -4454,6 +4459,258 @@ fn extract_handler(val: &JsValue) -> Option<crate::builtins::promise::PromiseHan
     }
 }
 
+// ── Intl ─────────────────────────────────────────────────────────────────────
+
+/// Build the `Intl` namespace object (ECMA-402).
+///
+/// Each property is a constructor-like `PlainObject` with a `__call__` method
+/// that returns an instance (another `PlainObject`) carrying a `format` (or
+/// `compare` / `select`) method.
+fn make_intl() -> JsValue {
+    let mut ns: HashMap<String, JsValue> = HashMap::new();
+
+    // ── Intl.NumberFormat ────────────────────────────────────────────────
+    ns.insert("NumberFormat".into(), {
+        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        ctor.insert(
+            "__call__".into(),
+            native(|_args| {
+                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                obj.insert("format".into(), native(|a| number_format_js(&a)));
+                obj.insert(
+                    "resolvedOptions".into(),
+                    native(|_| {
+                        let mut opts: HashMap<String, JsValue> = HashMap::new();
+                        opts.insert("locale".into(), JsValue::String("en-US".into()));
+                        opts.insert("numberingSystem".into(), JsValue::String("latn".into()));
+                        Ok(JsValue::PlainObject(Rc::new(RefCell::new(opts))))
+                    }),
+                );
+                Ok(JsValue::PlainObject(Rc::new(RefCell::new(obj))))
+            }),
+        );
+        JsValue::PlainObject(Rc::new(RefCell::new(ctor)))
+    });
+
+    // ── Intl.DateTimeFormat ──────────────────────────────────────────────
+    ns.insert("DateTimeFormat".into(), {
+        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        ctor.insert(
+            "__call__".into(),
+            native(|_args| {
+                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                obj.insert("format".into(), native(|a| date_time_format_js(&a)));
+                obj.insert(
+                    "resolvedOptions".into(),
+                    native(|_| {
+                        let mut opts: HashMap<String, JsValue> = HashMap::new();
+                        opts.insert("locale".into(), JsValue::String("en-US".into()));
+                        opts.insert("calendar".into(), JsValue::String("gregory".into()));
+                        opts.insert("timeZone".into(), JsValue::String("UTC".into()));
+                        Ok(JsValue::PlainObject(Rc::new(RefCell::new(opts))))
+                    }),
+                );
+                Ok(JsValue::PlainObject(Rc::new(RefCell::new(obj))))
+            }),
+        );
+        JsValue::PlainObject(Rc::new(RefCell::new(ctor)))
+    });
+
+    // ── Intl.Collator ───────────────────────────────────────────────────
+    ns.insert("Collator".into(), {
+        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        ctor.insert(
+            "__call__".into(),
+            native(|_args| {
+                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                obj.insert("compare".into(), native(|a| collator_compare_js(&a)));
+                obj.insert(
+                    "resolvedOptions".into(),
+                    native(|_| {
+                        let mut opts: HashMap<String, JsValue> = HashMap::new();
+                        opts.insert("locale".into(), JsValue::String("en-US".into()));
+                        opts.insert("sensitivity".into(), JsValue::String("variant".into()));
+                        Ok(JsValue::PlainObject(Rc::new(RefCell::new(opts))))
+                    }),
+                );
+                Ok(JsValue::PlainObject(Rc::new(RefCell::new(obj))))
+            }),
+        );
+        JsValue::PlainObject(Rc::new(RefCell::new(ctor)))
+    });
+
+    // ── Intl.PluralRules ────────────────────────────────────────────────
+    ns.insert("PluralRules".into(), {
+        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        ctor.insert(
+            "__call__".into(),
+            native(|_args| {
+                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                obj.insert("select".into(), native(|a| plural_rules_select_js(&a)));
+                obj.insert(
+                    "resolvedOptions".into(),
+                    native(|_| {
+                        let mut opts: HashMap<String, JsValue> = HashMap::new();
+                        opts.insert("locale".into(), JsValue::String("en-US".into()));
+                        opts.insert("type".into(), JsValue::String("cardinal".into()));
+                        Ok(JsValue::PlainObject(Rc::new(RefCell::new(opts))))
+                    }),
+                );
+                Ok(JsValue::PlainObject(Rc::new(RefCell::new(obj))))
+            }),
+        );
+        JsValue::PlainObject(Rc::new(RefCell::new(ctor)))
+    });
+
+    // ── Intl.ListFormat ─────────────────────────────────────────────────
+    ns.insert("ListFormat".into(), {
+        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        ctor.insert(
+            "__call__".into(),
+            native(|args| {
+                let list_type = if let Some(JsValue::PlainObject(opts)) = args.get(1) {
+                    opts.borrow()
+                        .get("type")
+                        .and_then(|v| {
+                            if let JsValue::String(s) = v {
+                                Some(s.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or_else(|| "conjunction".to_string())
+                } else {
+                    "conjunction".to_string()
+                };
+                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                obj.insert(
+                    "format".into(),
+                    native(move |a| list_format_js(&a, &list_type)),
+                );
+                Ok(JsValue::PlainObject(Rc::new(RefCell::new(obj))))
+            }),
+        );
+        JsValue::PlainObject(Rc::new(RefCell::new(ctor)))
+    });
+
+    // ── Intl.RelativeTimeFormat ─────────────────────────────────────────
+    ns.insert("RelativeTimeFormat".into(), {
+        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        ctor.insert(
+            "__call__".into(),
+            native(|_args| {
+                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                obj.insert("format".into(), native(|a| relative_time_format_js(&a)));
+                Ok(JsValue::PlainObject(Rc::new(RefCell::new(obj))))
+            }),
+        );
+        JsValue::PlainObject(Rc::new(RefCell::new(ctor)))
+    });
+
+    // ── Intl.Segmenter ──────────────────────────────────────────────────
+    ns.insert("Segmenter".into(), {
+        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        ctor.insert(
+            "__call__".into(),
+            native(|_args| {
+                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                obj.insert(
+                    "segment".into(),
+                    native(|a| {
+                        let s = a.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+                        let segs: Vec<JsValue> = segmenter_segment(&s)
+                            .into_iter()
+                            .map(JsValue::String)
+                            .collect();
+                        Ok(JsValue::Array(Rc::new(segs)))
+                    }),
+                );
+                Ok(JsValue::PlainObject(Rc::new(RefCell::new(obj))))
+            }),
+        );
+        JsValue::PlainObject(Rc::new(RefCell::new(ctor)))
+    });
+
+    // ── Intl.DisplayNames ───────────────────────────────────────────────
+    ns.insert("DisplayNames".into(), {
+        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        ctor.insert(
+            "__call__".into(),
+            native(|_args| {
+                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                obj.insert(
+                    "of".into(),
+                    native(|a| {
+                        let code = a.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+                        Ok(JsValue::String(display_names_of(&code)))
+                    }),
+                );
+                Ok(JsValue::PlainObject(Rc::new(RefCell::new(obj))))
+            }),
+        );
+        JsValue::PlainObject(Rc::new(RefCell::new(ctor)))
+    });
+
+    // ── Intl.Locale ─────────────────────────────────────────────────────
+    ns.insert("Locale".into(), {
+        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        ctor.insert(
+            "__call__".into(),
+            native(|args| {
+                let tag = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                obj.insert("language".into(), JsValue::String(locale_language(&tag)));
+                obj.insert("baseName".into(), JsValue::String(locale_base_name(&tag)));
+                obj.insert(
+                    "toString".into(),
+                    native(move |_| Ok(JsValue::String(tag.clone()))),
+                );
+                Ok(JsValue::PlainObject(Rc::new(RefCell::new(obj))))
+            }),
+        );
+        JsValue::PlainObject(Rc::new(RefCell::new(ctor)))
+    });
+
+    // ── Intl.getCanonicalLocales ────────────────────────────────────────
+    ns.insert(
+        "getCanonicalLocales".into(),
+        native(|args| {
+            let locales: Vec<JsValue> = match args.first() {
+                Some(JsValue::Array(arr)) => arr
+                    .iter()
+                    .map(|v| match v {
+                        JsValue::String(s) => Ok(JsValue::String(s.clone())),
+                        other => Ok(JsValue::String(other.to_js_string()?)),
+                    })
+                    .collect::<StatorResult<Vec<_>>>()?,
+                Some(JsValue::String(s)) => vec![JsValue::String(s.clone())],
+                _ => Vec::new(),
+            };
+            Ok(JsValue::Array(Rc::new(locales)))
+        }),
+    );
+
+    // ── Intl.supportedValuesOf ──────────────────────────────────────────
+    ns.insert(
+        "supportedValuesOf".into(),
+        native(|args| {
+            let key = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+            let values: Vec<JsValue> = match key.as_str() {
+                "calendar" => vec![JsValue::String("gregory".into())],
+                "collation" => vec![JsValue::String("default".into())],
+                "currency" => vec![JsValue::String("USD".into())],
+                "numberingSystem" => vec![JsValue::String("latn".into())],
+                "timeZone" => vec![JsValue::String("UTC".into())],
+                "unit" => vec![],
+                _ => Vec::new(),
+            };
+            Ok(JsValue::Array(Rc::new(values)))
+        }),
+    );
+
+    JsValue::PlainObject(Rc::new(RefCell::new(ns)))
+}
+
 // ── install_globals ──────────────────────────────────────────────────────────
 
 /// Pre-populate `globals` with all ECMAScript built-in names.
@@ -4467,6 +4724,7 @@ pub fn install_globals(globals: &mut HashMap<String, JsValue>) {
     globals.insert("Math".into(), make_math());
     globals.insert("console".into(), make_console());
     globals.insert("JSON".into(), make_json());
+    globals.insert("Intl".into(), make_intl());
 
     // ── Constructor / namespace objects ──────────────────────────────────
     globals.insert("Number".into(), make_number());
@@ -4650,6 +4908,7 @@ mod tests {
         assert!(globals.contains_key("BigInt"));
         assert!(globals.contains_key("Function"));
         assert!(globals.contains_key("globalThis"));
+        assert!(globals.contains_key("Intl"));
         // Error constructors
         assert!(globals.contains_key("Error"));
         assert!(globals.contains_key("TypeError"));

--- a/crates/stator_core/src/builtins/intl.rs
+++ b/crates/stator_core/src/builtins/intl.rs
@@ -1,0 +1,371 @@
+//! ECMA-402 `Intl` namespace — basic stub implementations.
+//!
+//! Provides the `Intl` global namespace with constructor stubs for:
+//! - `Intl.NumberFormat`
+//! - `Intl.DateTimeFormat`
+//! - `Intl.Collator`
+//! - `Intl.PluralRules`
+//! - `Intl.ListFormat`
+//! - `Intl.RelativeTimeFormat`
+//! - `Intl.Segmenter`
+//! - `Intl.DisplayNames`
+//! - `Intl.Locale`
+//!
+//! This initial implementation uses Rust standard library formatting and
+//! returns reasonable en-US results.  Full ICU (icu4x) support is deferred.
+
+use std::cmp::Ordering;
+
+use crate::error::StatorResult;
+use crate::objects::value::JsValue;
+
+// ── NumberFormat ──────────────────────────────────────────────────────────────
+
+/// Format a number as a decimal string.
+///
+/// This stub always uses the default Rust `Display` formatter which produces
+/// output comparable to `en-US` locale formatting without grouping separators.
+pub fn number_format(value: f64) -> String {
+    if value.is_nan() {
+        return "NaN".to_string();
+    }
+    if value.is_infinite() {
+        return if value.is_sign_positive() {
+            "∞".to_string()
+        } else {
+            "-∞".to_string()
+        };
+    }
+    // Remove trailing ".0" for integral values to match JS behaviour.
+    if value.fract() == 0.0 && value.abs() < (i64::MAX as f64) {
+        format!("{}", value as i64)
+    } else {
+        format!("{value}")
+    }
+}
+
+// ── DateTimeFormat ───────────────────────────────────────────────────────────
+
+/// Format a millisecond-since-epoch timestamp as a human-readable date string.
+///
+/// Returns a basic ISO-8601-like representation.  Full locale-aware formatting
+/// will be provided once icu4x integration lands.
+pub fn date_time_format(ms_epoch: f64) -> String {
+    if ms_epoch.is_nan() || ms_epoch.is_infinite() {
+        return "Invalid Date".to_string();
+    }
+    let secs = (ms_epoch / 1000.0).trunc() as i64;
+    let (year, month, day, hour, min, sec) = epoch_to_components(secs);
+    format!("{month}/{day}/{year}, {hour}:{min:02}:{sec:02} AM")
+}
+
+/// Convert Unix epoch seconds to calendar components (UTC).
+fn epoch_to_components(epoch_secs: i64) -> (i64, u32, u32, u32, u32, u32) {
+    // Civil date from epoch using the algorithm from
+    // <https://howardhinnant.github.io/date_algorithms.html>.
+    let z = epoch_secs.div_euclid(86400) + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097) as u64; // day of era
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // day of year
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+
+    let day_secs = epoch_secs.rem_euclid(86400) as u32;
+    let h = day_secs / 3600;
+    let min = (day_secs % 3600) / 60;
+    let sec = day_secs % 60;
+
+    (y, m, d, h, min, sec)
+}
+
+// ── Collator ─────────────────────────────────────────────────────────────────
+
+/// Compare two strings using byte-level (code-unit) ordering.
+///
+/// Returns `−1`, `0`, or `1` matching the `Intl.Collator.prototype.compare`
+/// contract.  Locale-sensitive collation will be added with icu4x.
+pub fn collator_compare(a: &str, b: &str) -> i32 {
+    match a.cmp(b) {
+        Ordering::Less => -1,
+        Ordering::Equal => 0,
+        Ordering::Greater => 1,
+    }
+}
+
+// ── PluralRules ──────────────────────────────────────────────────────────────
+
+/// Select the CLDR plural category for a number (en-US rules).
+///
+/// Returns `"one"` for 1, `"other"` for everything else.  Full CLDR plural
+/// rules for additional locales will come with icu4x.
+pub fn plural_rules_select(n: f64) -> &'static str {
+    if n == 1.0 { "one" } else { "other" }
+}
+
+// ── ListFormat ───────────────────────────────────────────────────────────────
+
+/// Join a list of strings using English conjunction rules.
+///
+/// `list_type` accepts `"conjunction"` (default, "and") or `"disjunction"` ("or").
+pub fn list_format(items: &[String], list_type: &str) -> String {
+    let conjunction = if list_type == "disjunction" {
+        "or"
+    } else {
+        "and"
+    };
+    match items.len() {
+        0 => String::new(),
+        1 => items[0].clone(),
+        2 => format!("{} {conjunction} {}", items[0], items[1]),
+        _ => {
+            let last = items.len() - 1;
+            let head = items[..last].join(", ");
+            format!("{head}, {conjunction} {}", items[last])
+        }
+    }
+}
+
+// ── RelativeTimeFormat ───────────────────────────────────────────────────────
+
+/// Format a relative time value (en-US, long style).
+///
+/// `unit` must be one of `"second"`, `"minute"`, `"hour"`, `"day"`, `"week"`,
+/// `"month"`, `"quarter"`, or `"year"`.
+pub fn relative_time_format(value: f64, unit: &str) -> String {
+    let abs = value.abs();
+    let plural = if abs == 1.0 {
+        unit
+    } else {
+        &format!("{unit}s")
+    };
+    if value < 0.0 {
+        format!("{abs} {plural} ago")
+    } else if value > 0.0 {
+        format!("in {abs} {plural}")
+    } else {
+        format!("in 0 {plural}")
+    }
+}
+
+// ── Segmenter ────────────────────────────────────────────────────────────────
+
+/// Segment a string into grapheme clusters (stub: splits on UTF-8 char boundaries).
+pub fn segmenter_segment(input: &str) -> Vec<String> {
+    input.chars().map(|c| c.to_string()).collect()
+}
+
+// ── DisplayNames ─────────────────────────────────────────────────────────────
+
+/// Return a display name for a code.  Stub returns the code itself.
+pub fn display_names_of(code: &str) -> String {
+    code.to_string()
+}
+
+// ── Locale ───────────────────────────────────────────────────────────────────
+
+/// Parse a BCP-47 locale tag and return the language subtag.
+pub fn locale_language(tag: &str) -> String {
+    tag.split('-').next().unwrap_or("und").to_string()
+}
+
+/// Return the full canonicalised tag (stub: returns input unchanged).
+pub fn locale_base_name(tag: &str) -> String {
+    tag.to_string()
+}
+
+// ── JsValue helpers ──────────────────────────────────────────────────────────
+
+/// Convert a numeric `JsValue` to the formatted string produced by
+/// `Intl.NumberFormat.prototype.format`.
+pub fn number_format_js(args: &[JsValue]) -> StatorResult<JsValue> {
+    let n = args.first().unwrap_or(&JsValue::Undefined).to_number()?;
+    Ok(JsValue::String(number_format(n)))
+}
+
+/// Convert a timestamp `JsValue` to the formatted string produced by
+/// `Intl.DateTimeFormat.prototype.format`.
+pub fn date_time_format_js(args: &[JsValue]) -> StatorResult<JsValue> {
+    let ms = args.first().unwrap_or(&JsValue::Undefined).to_number()?;
+    Ok(JsValue::String(date_time_format(ms)))
+}
+
+/// Compare two string `JsValue`s using `Intl.Collator`.
+pub fn collator_compare_js(args: &[JsValue]) -> StatorResult<JsValue> {
+    let a = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
+    let b = args.get(1).unwrap_or(&JsValue::Undefined).to_js_string()?;
+    Ok(JsValue::Smi(collator_compare(&a, &b)))
+}
+
+/// Select the plural category for a number.
+pub fn plural_rules_select_js(args: &[JsValue]) -> StatorResult<JsValue> {
+    let n = args.first().unwrap_or(&JsValue::Undefined).to_number()?;
+    Ok(JsValue::String(plural_rules_select(n).to_string()))
+}
+
+/// Format a JS array of strings using `Intl.ListFormat`.
+pub fn list_format_js(args: &[JsValue], list_type: &str) -> StatorResult<JsValue> {
+    let items: Vec<String> = match args.first() {
+        Some(JsValue::Array(arr)) => arr
+            .iter()
+            .map(|v| v.to_js_string())
+            .collect::<StatorResult<Vec<_>>>()?,
+        _ => Vec::new(),
+    };
+    Ok(JsValue::String(list_format(&items, list_type)))
+}
+
+/// Format a relative time.
+pub fn relative_time_format_js(args: &[JsValue]) -> StatorResult<JsValue> {
+    let value = args.first().unwrap_or(&JsValue::Undefined).to_number()?;
+    let unit = args.get(1).unwrap_or(&JsValue::Undefined).to_js_string()?;
+    Ok(JsValue::String(relative_time_format(value, &unit)))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_number_format_integer() {
+        assert_eq!(number_format(42.0), "42");
+    }
+
+    #[test]
+    fn test_number_format_decimal() {
+        assert_eq!(number_format(3.14), "3.14");
+    }
+
+    #[test]
+    fn test_number_format_nan() {
+        assert_eq!(number_format(f64::NAN), "NaN");
+    }
+
+    #[test]
+    fn test_number_format_infinity() {
+        assert_eq!(number_format(f64::INFINITY), "∞");
+        assert_eq!(number_format(f64::NEG_INFINITY), "-∞");
+    }
+
+    #[test]
+    fn test_date_time_format_epoch_zero() {
+        let s = date_time_format(0.0);
+        assert!(s.contains("1970"), "expected 1970 in '{s}'");
+    }
+
+    #[test]
+    fn test_date_time_format_invalid() {
+        assert_eq!(date_time_format(f64::NAN), "Invalid Date");
+    }
+
+    #[test]
+    fn test_collator_compare_equal() {
+        assert_eq!(collator_compare("abc", "abc"), 0);
+    }
+
+    #[test]
+    fn test_collator_compare_less() {
+        assert_eq!(collator_compare("abc", "def"), -1);
+    }
+
+    #[test]
+    fn test_collator_compare_greater() {
+        assert_eq!(collator_compare("def", "abc"), 1);
+    }
+
+    #[test]
+    fn test_plural_rules_one() {
+        assert_eq!(plural_rules_select(1.0), "one");
+    }
+
+    #[test]
+    fn test_plural_rules_other() {
+        assert_eq!(plural_rules_select(0.0), "other");
+        assert_eq!(plural_rules_select(2.0), "other");
+    }
+
+    #[test]
+    fn test_list_format_empty() {
+        assert_eq!(list_format(&[], "conjunction"), "");
+    }
+
+    #[test]
+    fn test_list_format_single() {
+        assert_eq!(list_format(&["one".to_string()], "conjunction"), "one");
+    }
+
+    #[test]
+    fn test_list_format_two() {
+        let items = vec!["A".to_string(), "B".to_string()];
+        assert_eq!(list_format(&items, "conjunction"), "A and B");
+        assert_eq!(list_format(&items, "disjunction"), "A or B");
+    }
+
+    #[test]
+    fn test_list_format_three() {
+        let items = vec!["A".to_string(), "B".to_string(), "C".to_string()];
+        assert_eq!(list_format(&items, "conjunction"), "A, B, and C");
+    }
+
+    #[test]
+    fn test_relative_time_format_past() {
+        assert_eq!(relative_time_format(-3.0, "day"), "3 days ago");
+    }
+
+    #[test]
+    fn test_relative_time_format_future() {
+        assert_eq!(relative_time_format(1.0, "hour"), "in 1 hour");
+    }
+
+    #[test]
+    fn test_relative_time_format_zero() {
+        assert_eq!(relative_time_format(0.0, "second"), "in 0 seconds");
+    }
+
+    #[test]
+    fn test_segmenter_segment_ascii() {
+        let segs = segmenter_segment("abc");
+        assert_eq!(segs, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_display_names_of_passthrough() {
+        assert_eq!(display_names_of("US"), "US");
+    }
+
+    #[test]
+    fn test_locale_language() {
+        assert_eq!(locale_language("en-US"), "en");
+        assert_eq!(locale_language("fr"), "fr");
+    }
+
+    #[test]
+    fn test_locale_base_name() {
+        assert_eq!(locale_base_name("en-US"), "en-US");
+    }
+
+    #[test]
+    fn test_number_format_js_value() {
+        let result = number_format_js(&[JsValue::HeapNumber(42.5)]).unwrap();
+        assert_eq!(result, JsValue::String("42.5".into()));
+    }
+
+    #[test]
+    fn test_collator_compare_js_value() {
+        let result =
+            collator_compare_js(&[JsValue::String("a".into()), JsValue::String("b".into())])
+                .unwrap();
+        assert_eq!(result, JsValue::Smi(-1));
+    }
+
+    #[test]
+    fn test_plural_rules_select_js_value() {
+        let result = plural_rules_select_js(&[JsValue::Smi(1)]).unwrap();
+        assert_eq!(result, JsValue::String("one".into()));
+    }
+}

--- a/crates/stator_core/src/builtins/mod.rs
+++ b/crates/stator_core/src/builtins/mod.rs
@@ -22,6 +22,8 @@ pub mod global;
 /// objects, and global functions so that JavaScript code can access `Math`,
 /// `console`, `JSON`, `parseInt`, etc.
 pub mod install_globals;
+/// ECMA-402 `Intl` namespace — internationalization constructors and formatters.
+pub mod intl;
 /// ECMAScript §27 Iterator and Generator protocol: `Symbol.iterator`,
 /// `IteratorRecord`, and built-in iterators for `Array`, `String`, `Map`, `Set`.
 pub mod iterator;


### PR DESCRIPTION
## Summary

Implements the ECMA-402 \Intl\ namespace object with stub constructors for all nine constructors listed in #305:

- **Intl.NumberFormat** — decimal formatting via Rust \Display\
- **Intl.DateTimeFormat** — basic UTC date/time string from epoch ms
- **Intl.Collator** — code-unit string comparison (\-1\/\