### PR TITLE
feat: tail call optimization (closes #309)

### DIFF
--- a/crates/stator_core/src/bytecode/bytecode_generator.rs
+++ b/crates/stator_core/src/bytecode/bytecode_generator.rs
@@ -219,6 +219,12 @@ struct FunctionCompiler {
     module_variables: HashMap<String, (u32, i32)>,
     /// Counter for assigning unique cell indices to module variable bindings.
     next_module_cell: i32,
+    /// `true` when the expression currently being compiled is in tail
+    /// position (i.e. its value is immediately returned).  Set by
+    /// [`compile_return`] and consumed by [`compile_call`] /
+    /// [`compile_method_call`] to emit [`Opcode::TailCall`] instead of a
+    /// regular call.
+    in_tail_position: bool,
 }
 
 impl FunctionCompiler {
@@ -252,6 +258,7 @@ impl FunctionCompiler {
             is_module: false,
             module_variables: HashMap::new(),
             next_module_cell: 0,
+            in_tail_position: false,
         };
         // Register simple ident params in the scope immediately; complex
         // patterns are handled by `emit_param_prologue`.
@@ -1204,6 +1211,7 @@ impl FunctionCompiler {
             is_module: false,
             module_variables: HashMap::new(),
             next_module_cell: 0,
+            in_tail_position: false,
         };
 
         let this_reg = Register::parameter(0);
@@ -1433,7 +1441,11 @@ impl FunctionCompiler {
     /// Compile a `return [argument]` statement.
     fn compile_return(&mut self, s: &crate::parser::ast::ReturnStmt) -> StatorResult<()> {
         if let Some(arg) = &s.argument {
+            // Mark expressions in return position as tail calls so that
+            // compile_call / compile_conditional can emit TailCall opcodes.
+            self.in_tail_position = true;
             self.compile_expr(arg)?;
+            self.in_tail_position = false;
         } else {
             self.emit(Instruction::new_unchecked(Opcode::LdaUndefined, vec![]));
         }
@@ -1707,6 +1719,18 @@ impl FunctionCompiler {
 
     /// Compile an expression, leaving the result in the accumulator.
     fn compile_expr(&mut self, expr: &Expr) -> StatorResult<()> {
+        // Only Call, Conditional, Logical, and Sequence expressions can
+        // propagate tail position to sub-expressions.  All other expression
+        // types clear the flag so that nested calls are not incorrectly
+        // marked as tail calls (e.g. `return n + f(n-1)` — the call f() is
+        // NOT in tail position because its result feeds into `+`).
+        match expr {
+            Expr::Call(_) | Expr::Conditional(_) | Expr::Logical(_) | Expr::Sequence(_) => {}
+            _ => {
+                self.in_tail_position = false;
+            }
+        }
+
         match expr {
             // ── Literals ──────────────────────────────────────────────────
             Expr::Null(_) => {
@@ -1826,9 +1850,15 @@ impl FunctionCompiler {
             Expr::Conditional(c) => self.compile_conditional(c),
             Expr::Assign(a) => self.compile_assign(a),
             Expr::Sequence(s) => {
-                for expr in &s.expressions {
+                let saved_tail = self.in_tail_position;
+                let len = s.expressions.len();
+                for (i, expr) in s.expressions.iter().enumerate() {
+                    // Only the last expression in a comma sequence inherits
+                    // tail position; all preceding ones are for side effects.
+                    self.in_tail_position = saved_tail && i == len - 1;
                     self.compile_expr(expr)?;
                 }
+                self.in_tail_position = false;
                 Ok(())
             }
 
@@ -2127,7 +2157,10 @@ impl FunctionCompiler {
     fn compile_logical(&mut self, l: &crate::parser::ast::LogicalExpr) -> StatorResult<()> {
         let end_label = self.new_label();
 
+        let saved_tail = self.in_tail_position;
+        self.in_tail_position = false;
         self.compile_expr(&l.left)?;
+        self.in_tail_position = saved_tail;
 
         match l.op {
             LogicalOp::And => {
@@ -2147,12 +2180,14 @@ impl FunctionCompiler {
                 self.emit_jump(Opcode::Jump, end_label);
                 self.bind_label(eval_right_label);
                 self.compile_expr(&l.right)?;
+                self.in_tail_position = false;
                 self.bind_label(end_label);
                 return Ok(());
             }
         }
 
         self.compile_expr(&l.right)?;
+        self.in_tail_position = false;
         self.bind_label(end_label);
         Ok(())
     }
@@ -2162,12 +2197,17 @@ impl FunctionCompiler {
         let else_label = self.new_label();
         let end_label = self.new_label();
 
+        let saved_tail = self.in_tail_position;
+        self.in_tail_position = false;
         self.compile_expr(&c.test)?;
         self.emit_jump(Opcode::JumpIfToBooleanFalse, else_label);
+        self.in_tail_position = saved_tail;
         self.compile_expr(&c.consequent)?;
         self.emit_jump(Opcode::Jump, end_label);
         self.bind_label(else_label);
+        self.in_tail_position = saved_tail;
         self.compile_expr(&c.alternate)?;
+        self.in_tail_position = false;
         self.bind_label(end_label);
         Ok(())
     }
@@ -2454,8 +2494,14 @@ impl FunctionCompiler {
 
     /// Compile a call expression `callee(args…)`.
     fn compile_call(&mut self, c: &crate::parser::ast::CallExpr) -> StatorResult<()> {
+        // Consume the tail-position flag before compiling sub-expressions.
+        let is_tail = self.in_tail_position;
+        self.in_tail_position = false;
+
         // Check for method call: `obj.method(args)`.
         if let Expr::Member(m) = c.callee.as_ref() {
+            // Propagate tail position into method call compilation.
+            self.in_tail_position = is_tail;
             return self.compile_method_call(m, &c.arguments);
         }
 
@@ -2472,6 +2518,8 @@ impl FunctionCompiler {
 
         if is_direct_eval {
             self.emit_call_direct_eval(callee_reg, &arg_regs)?;
+        } else if is_tail {
+            self.emit_tail_call(callee_reg, &arg_regs)?;
         } else {
             self.emit_call_any_receiver(callee_reg, &arg_regs)?;
         }
@@ -2570,6 +2618,10 @@ impl FunctionCompiler {
         m: &crate::parser::ast::MemberExpr,
         args: &[Expr],
     ) -> StatorResult<()> {
+        // Consume tail-position flag — method calls in tail position are not
+        // optimised (the receiver binding requires a full frame), so we clear
+        // it to prevent inner expressions from being incorrectly marked.
+        self.in_tail_position = false;
         // Load the object (receiver).
         self.compile_expr(&m.object)?;
         let recv_reg = self.allocator.allocate_temporary();
@@ -2663,6 +2715,25 @@ impl FunctionCompiler {
         let slot = self.alloc_slot(FeedbackSlotKind::Call);
         self.emit(Instruction::new_unchecked(
             Opcode::CallAnyReceiver,
+            vec![
+                to_reg_op(callee_reg),
+                to_reg_op(args_start),
+                Operand::RegisterCount(arg_count),
+                slot,
+            ],
+        ));
+        Ok(())
+    }
+
+    /// Emit a `TailCall` instruction (same operand layout as
+    /// [`Self::emit_call_any_receiver`] but signals tail-position semantics
+    /// so the interpreter can reuse the current frame).
+    fn emit_tail_call(&mut self, callee_reg: Register, arg_regs: &[Register]) -> StatorResult<()> {
+        let arg_count = arg_regs.len() as u32;
+        let args_start = arg_regs.first().copied().unwrap_or(callee_reg);
+        let slot = self.alloc_slot(FeedbackSlotKind::Call);
+        self.emit(Instruction::new_unchecked(
+            Opcode::TailCall,
             vec![
                 to_reg_op(callee_reg),
                 to_reg_op(args_start),

--- a/crates/stator_core/src/bytecode/bytecodes.rs
+++ b/crates/stator_core/src/bytecode/bytecodes.rs
@@ -448,6 +448,14 @@ pub enum Opcode {
     /// a normal call is performed.  `[callable, args_start, args_count, slot]`
     CallDirectEval,
 
+    /// Tail call in return position (ES2015 proper tail calls).
+    /// Same operand layout as `CallAnyReceiver`:
+    /// `[callable, args_start, args_count, slot]`.
+    ///
+    /// The interpreter reuses the current call frame instead of pushing a
+    /// new one, preventing stack growth for recursive tail-position calls.
+    TailCall,
+
     // ── Construct ─────────────────────────────────────────────────────────
     /// `new constructor(args…)`. `[constructor, args_start, args_count, slot]`
     Construct,
@@ -798,6 +806,7 @@ impl Opcode {
             Opcode::CallJSRuntime => &[ConstantPoolIdx, Register, RegisterCount],
             Opcode::InvokeIntrinsic => &[RuntimeId, Register, RegisterCount],
             Opcode::CallDirectEval => &[Register, Register, RegisterCount, FeedbackSlot],
+            Opcode::TailCall => &[Register, Register, RegisterCount, FeedbackSlot],
 
             // Construct
             Opcode::Construct => &[Register, Register, RegisterCount, FeedbackSlot],

--- a/crates/stator_core/src/compiler/baseline/compiler.rs
+++ b/crates/stator_core/src/compiler/baseline/compiler.rs
@@ -1051,6 +1051,7 @@ impl<'a> BaselineCompiler<'a> {
             | Opcode::CallJSRuntime
             | Opcode::InvokeIntrinsic
             | Opcode::CallDirectEval
+            | Opcode::TailCall
             | Opcode::Construct
             | Opcode::ConstructWithSpread
             | Opcode::ConstructForwardAllArgs

--- a/crates/stator_core/src/interpreter/mod.rs
+++ b/crates/stator_core/src/interpreter/mod.rs
@@ -885,3239 +885,1160 @@ impl Interpreter {
     /// - an unimplemented opcode is encountered, or
     /// - a type error occurs during arithmetic.
     pub fn run(frame: &mut InterpreterFrame) -> StatorResult<JsValue> {
-        // Pre-decode the bytecode once and capture byte offsets for jump resolution.
-        let (instructions, byte_offsets) =
-            decode_with_byte_offsets(frame.bytecode_array.bytecodes())?;
-        // Clone the handler table once so the borrow on bytecode_array is released
-        // before we start mutating the frame.
-        let handler_table: Vec<HandlerTableEntry> = frame.bytecode_array.handler_table().to_vec();
-
-        loop {
-            // ── CPU profiler checkpoint ────────────────────────────────────
-            crate::inspector::profiler::maybe_record_sample();
-
-            if frame.pc >= instructions.len() {
-                return Err(StatorError::Internal(
-                    "bytecode ended without a Return instruction".into(),
-                ));
-            }
-
-            // ── Debug hook (pre-fetch) ─────────────────────────────────────
-            //
-            // Check for breakpoints and step conditions *before* fetching the
-            // next instruction so that the paused frame state reflects what is
-            // *about* to execute (the program counter still points at the
-            // instruction that would fire next).
-            let current_offset = byte_offsets[frame.pc] as u32;
-            if let Some(pause_err) = ACTIVE_DEBUGGER.with(|d| {
-                let opt = d.borrow();
-                opt.as_ref()
-                    .and_then(|rc| rc.borrow_mut().check_pause_at(current_offset))
-            }) {
-                return Err(pause_err);
-            }
-
-            // ── Fetch ──────────────────────────────────────────────────────
-            let instr = &instructions[frame.pc];
-            frame.pc += 1;
-
-            // ── Instruction limit check ────────────────────────────────────
-            if frame.instruction_limit > 0 {
-                frame.instructions_executed += 1;
-                if frame.instructions_executed > frame.instruction_limit {
-                    return Err(StatorError::Internal("instruction limit exceeded".into()));
-                }
-            }
-
-            // ── Decode + Dispatch ──────────────────────────────────────────
-            match instr.opcode {
-                // ── Load immediates ────────────────────────────────────────
-                Opcode::LdaZero => {
-                    frame.accumulator = JsValue::Smi(0);
-                }
-                Opcode::LdaSmi => {
-                    let Operand::Immediate(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaSmi", 0));
-                    };
-                    frame.accumulator = JsValue::Smi(v);
-                }
-                Opcode::LdaUndefined => {
-                    frame.accumulator = JsValue::Undefined;
-                }
-                Opcode::LdaNull => {
-                    frame.accumulator = JsValue::Null;
-                }
-                Opcode::LdaTrue => {
-                    frame.accumulator = JsValue::Boolean(true);
-                }
-                Opcode::LdaFalse => {
-                    frame.accumulator = JsValue::Boolean(false);
-                }
-                Opcode::LdaConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaConstant", 0));
-                    };
-                    let entry = frame.bytecode_array.get_constant(idx).ok_or_else(|| {
-                        StatorError::Internal(format!("constant pool index {idx} out of bounds"))
-                    })?;
-                    frame.accumulator = constant_to_value(entry);
-                }
-
-                // ── Register moves ─────────────────────────────────────────
-                Opcode::Ldar => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("Ldar", 0));
-                    };
-                    frame.accumulator = frame.read_reg(v)?.clone();
-                }
-                Opcode::Star => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("Star", 0));
-                    };
-                    let val = frame.accumulator.clone();
-                    frame.write_reg(v, val)?;
-                }
-                Opcode::Mov => {
-                    let Operand::Register(src) = instr.operands[0] else {
-                        return Err(err_bad_operand("Mov", 0));
-                    };
-                    let Operand::Register(dst) = instr.operands[1] else {
-                        return Err(err_bad_operand("Mov", 1));
-                    };
-                    let val = frame.read_reg(src)?.clone();
-                    frame.write_reg(dst, val)?;
-                }
-
-                // ── Arithmetic ─────────────────────────────────────────────
-                //
-                // Convention (V8 Ignition): the bytecode generator evaluates
-                // LHS → accumulator and saves RHS to a temporary register
-                // before emitting the arithmetic opcode.  From the
-                // interpreter's point of view: acc = acc <op> reg.
-                Opcode::Add => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("Add", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    frame.accumulator = js_add(&frame.accumulator, &rhs)?;
-                }
-                Opcode::Sub => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("Sub", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    if frame.accumulator.is_bigint() || rhs.is_bigint() {
-                        let l = to_bigint(&frame.accumulator)?;
-                        let r = to_bigint(&rhs)?;
-                        frame.accumulator = JsValue::BigInt(l.wrapping_sub(r));
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        let rhs_n = rhs.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n - rhs_n);
-                    }
-                }
-                Opcode::Mul => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("Mul", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    if frame.accumulator.is_bigint() || rhs.is_bigint() {
-                        let l = to_bigint(&frame.accumulator)?;
-                        let r = to_bigint(&rhs)?;
-                        frame.accumulator = JsValue::BigInt(l.wrapping_mul(r));
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        let rhs_n = rhs.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n * rhs_n);
-                    }
-                }
-                Opcode::Div => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("Div", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    if frame.accumulator.is_bigint() || rhs.is_bigint() {
-                        let l = to_bigint(&frame.accumulator)?;
-                        let r = to_bigint(&rhs)?;
-                        if r == 0 {
-                            return Err(StatorError::RangeError("Division by zero".to_string()));
-                        }
-                        frame.accumulator = JsValue::BigInt(l / r);
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        let rhs_n = rhs.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n / rhs_n);
-                    }
-                }
-                Opcode::Mod => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("Mod", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    if frame.accumulator.is_bigint() || rhs.is_bigint() {
-                        let l = to_bigint(&frame.accumulator)?;
-                        let r = to_bigint(&rhs)?;
-                        if r == 0 {
-                            return Err(StatorError::RangeError("Division by zero".to_string()));
-                        }
-                        frame.accumulator = JsValue::BigInt(l % r);
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        let rhs_n = rhs.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n % rhs_n);
-                    }
-                }
-                Opcode::Exp => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("Exp", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    if frame.accumulator.is_bigint() || rhs.is_bigint() {
-                        let l = to_bigint(&frame.accumulator)?;
-                        let r = to_bigint(&rhs)?;
-                        if r < 0 {
-                            return Err(StatorError::RangeError(
-                                "Exponent must be positive".to_string(),
-                            ));
-                        }
-                        frame.accumulator = JsValue::BigInt(bigint_pow(l, r as u32));
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        let rhs_n = rhs.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n.powf(rhs_n));
-                    }
-                }
-                Opcode::BitwiseOr => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("BitwiseOr", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    if frame.accumulator.is_bigint() || rhs.is_bigint() {
-                        let l = to_bigint(&frame.accumulator)?;
-                        let r = to_bigint(&rhs)?;
-                        frame.accumulator = JsValue::BigInt(l | r);
-                    } else {
-                        let lhs = frame.accumulator.to_number()? as i32;
-                        let rhs_i = rhs.to_number()? as i32;
-                        frame.accumulator = JsValue::Smi(lhs | rhs_i);
-                    }
-                }
-                Opcode::BitwiseXor => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("BitwiseXor", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    if frame.accumulator.is_bigint() || rhs.is_bigint() {
-                        let l = to_bigint(&frame.accumulator)?;
-                        let r = to_bigint(&rhs)?;
-                        frame.accumulator = JsValue::BigInt(l ^ r);
-                    } else {
-                        let lhs = frame.accumulator.to_number()? as i32;
-                        let rhs_i = rhs.to_number()? as i32;
-                        frame.accumulator = JsValue::Smi(lhs ^ rhs_i);
-                    }
-                }
-                Opcode::BitwiseAnd => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("BitwiseAnd", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    if frame.accumulator.is_bigint() || rhs.is_bigint() {
-                        let l = to_bigint(&frame.accumulator)?;
-                        let r = to_bigint(&rhs)?;
-                        frame.accumulator = JsValue::BigInt(l & r);
-                    } else {
-                        let lhs = frame.accumulator.to_number()? as i32;
-                        let rhs_i = rhs.to_number()? as i32;
-                        frame.accumulator = JsValue::Smi(lhs & rhs_i);
-                    }
-                }
-                Opcode::ShiftLeft => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("ShiftLeft", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    if frame.accumulator.is_bigint() || rhs.is_bigint() {
-                        let l = to_bigint(&frame.accumulator)?;
-                        let r = to_bigint(&rhs)?;
-                        frame.accumulator = JsValue::BigInt(l.wrapping_shl(r as u32));
-                    } else {
-                        let lhs = frame.accumulator.to_number()? as i32;
-                        let shift = (rhs.to_number()? as u32) & 0x1f;
-                        frame.accumulator = JsValue::Smi(lhs << shift);
-                    }
-                }
-                Opcode::ShiftRight => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("ShiftRight", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    if frame.accumulator.is_bigint() || rhs.is_bigint() {
-                        let l = to_bigint(&frame.accumulator)?;
-                        let r = to_bigint(&rhs)?;
-                        frame.accumulator = JsValue::BigInt(l.wrapping_shr(r as u32));
-                    } else {
-                        let lhs = frame.accumulator.to_number()? as i32;
-                        let shift = (rhs.to_number()? as u32) & 0x1f;
-                        frame.accumulator = JsValue::Smi(lhs >> shift);
-                    }
-                }
-                Opcode::ShiftRightLogical => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("ShiftRightLogical", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    let lhs = frame.accumulator.to_number()? as i32 as u32;
-                    let shift = (rhs.to_number()? as u32) & 0x1f;
-                    let result = lhs >> shift;
-                    frame.accumulator = number_to_jsvalue(result as f64);
-                }
-
-                // ── Smi immediate arithmetic ──────────────────────────────
-                Opcode::AddSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("AddSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n.wrapping_add(i128::from(imm)));
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n + imm as f64);
-                    }
-                }
-                Opcode::SubSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("SubSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n.wrapping_sub(i128::from(imm)));
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n - imm as f64);
-                    }
-                }
-                Opcode::MulSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("MulSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n.wrapping_mul(i128::from(imm)));
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n * imm as f64);
-                    }
-                }
-                Opcode::DivSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("DivSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        if imm == 0 {
-                            return Err(StatorError::RangeError("Division by zero".to_string()));
-                        }
-                        frame.accumulator = JsValue::BigInt(n / i128::from(imm));
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n / imm as f64);
-                    }
-                }
-                Opcode::ModSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("ModSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        if imm == 0 {
-                            return Err(StatorError::RangeError("Division by zero".to_string()));
-                        }
-                        frame.accumulator = JsValue::BigInt(n % i128::from(imm));
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n % imm as f64);
-                    }
-                }
-                Opcode::ExpSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("ExpSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        if imm < 0 {
-                            return Err(StatorError::RangeError(
-                                "Exponent must be positive".to_string(),
-                            ));
-                        }
-                        frame.accumulator = JsValue::BigInt(bigint_pow(*n, imm as u32));
-                    } else {
-                        let lhs_n = frame.accumulator.to_number()?;
-                        frame.accumulator = number_to_jsvalue(lhs_n.powf(imm as f64));
-                    }
-                }
-                Opcode::BitwiseOrSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("BitwiseOrSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n | i128::from(imm));
-                    } else {
-                        let lhs = frame.accumulator.to_number()? as i32;
-                        frame.accumulator = JsValue::Smi(lhs | imm);
-                    }
-                }
-                Opcode::BitwiseXorSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("BitwiseXorSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n ^ i128::from(imm));
-                    } else {
-                        let lhs = frame.accumulator.to_number()? as i32;
-                        frame.accumulator = JsValue::Smi(lhs ^ imm);
-                    }
-                }
-                Opcode::BitwiseAndSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("BitwiseAndSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n & i128::from(imm));
-                    } else {
-                        let lhs = frame.accumulator.to_number()? as i32;
-                        frame.accumulator = JsValue::Smi(lhs & imm);
-                    }
-                }
-                Opcode::ShiftLeftSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("ShiftLeftSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n.wrapping_shl(imm as u32));
-                    } else {
-                        let lhs = frame.accumulator.to_number()? as i32;
-                        let shift = (imm as u32) & 0x1f;
-                        frame.accumulator = JsValue::Smi(lhs << shift);
-                    }
-                }
-                Opcode::ShiftRightSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("ShiftRightSmi", 0));
-                    };
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n.wrapping_shr(imm as u32));
-                    } else {
-                        let lhs = frame.accumulator.to_number()? as i32;
-                        let shift = (imm as u32) & 0x1f;
-                        frame.accumulator = JsValue::Smi(lhs >> shift);
-                    }
-                }
-                Opcode::ShiftRightLogicalSmi => {
-                    let Operand::Immediate(imm) = instr.operands[0] else {
-                        return Err(err_bad_operand("ShiftRightLogicalSmi", 0));
-                    };
-                    let lhs = frame.accumulator.to_number()? as i32 as u32;
-                    let shift = (imm as u32) & 0x1f;
-                    let result = lhs >> shift;
-                    frame.accumulator = number_to_jsvalue(result as f64);
-                }
-
-                Opcode::Inc => {
-                    // operands[0] is a FeedbackSlot, ignored at runtime.
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n.wrapping_add(1));
-                    } else {
-                        let n = frame.accumulator.to_number()?;
-                        frame.accumulator = number_to_jsvalue(n + 1.0);
-                    }
-                }
-                Opcode::Dec => {
-                    // operands[0] is a FeedbackSlot, ignored at runtime.
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n.wrapping_sub(1));
-                    } else {
-                        let n = frame.accumulator.to_number()?;
-                        frame.accumulator = number_to_jsvalue(n - 1.0);
-                    }
-                }
-
-                // ── Comparisons ────────────────────────────────────────────
-                Opcode::TestEqual => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestEqual", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    let result = abstract_eq(&frame.accumulator, &rhs);
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-                Opcode::TestNotEqual => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestNotEqual", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    let result = !abstract_eq(&frame.accumulator, &rhs);
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-                Opcode::TestEqualStrict => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestEqualStrict", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    let result = strict_eq(&frame.accumulator, &rhs);
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-                Opcode::TestLessThan => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestLessThan", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    let result = js_less_than(&frame.accumulator, &rhs)?;
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-                Opcode::TestGreaterThan => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestGreaterThan", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    // a > b  ≡  b < a
-                    let result = js_less_than(&rhs, &frame.accumulator)?;
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-                Opcode::TestLessThanOrEqual => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestLessThanOrEqual", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    // a <= b  ≡  !(b < a)
-                    let result = !js_less_than(&rhs, &frame.accumulator)?;
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-                Opcode::TestGreaterThanOrEqual => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestGreaterThanOrEqual", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    // a >= b  ≡  !(a < b)
-                    let result = !js_less_than(&frame.accumulator, &rhs)?;
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-                Opcode::TestNull => {
-                    frame.accumulator = JsValue::Boolean(frame.accumulator.is_null());
-                }
-                Opcode::TestUndefined => {
-                    frame.accumulator = JsValue::Boolean(frame.accumulator.is_undefined());
-                }
-
-                // ── Logical / Boolean ──────────────────────────────────────
-                Opcode::LogicalNot => {
-                    // `!acc` — the compiler emits this when acc is already a
-                    // boolean.  We coerce via ToBoolean for safety.
-                    frame.accumulator = JsValue::Boolean(!frame.accumulator.to_boolean());
-                }
-                Opcode::ToBooleanLogicalNot => {
-                    // `!ToBoolean(acc)` — explicit coercion before negation.
-                    frame.accumulator = JsValue::Boolean(!frame.accumulator.to_boolean());
-                }
-
-                // ── Control flow ───────────────────────────────────────────
-                Opcode::Jump => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("Jump", 0));
-                    };
-                    frame.pc = resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                }
-                // JumpLoop [offset, loop_depth, slot] — same as unconditional Jump.
-                //
-                // OSR (on-stack replacement): every back-edge increments the
-                // OSR counter.  Once the count exceeds OSR_LOOP_THRESHOLD the
-                // enclosing function is compiled to baseline JIT (if it has not
-                // been compiled already), so that the *next call* to this
-                // function executes via native code.  Once the back-edge count
-                // exceeds MAGLEV_OSR_LOOP_THRESHOLD a Maglev background
-                // compilation is scheduled so that future calls use the
-                // optimised tier.  At TURBOFAN_OSR_LOOP_THRESHOLD a Turbofan
-                // background compilation is scheduled for the highest tier.
-                Opcode::JumpLoop => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpLoop", 0));
-                    };
-                    frame.pc = resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    frame.osr_loop_count = frame.osr_loop_count.saturating_add(1);
-                    if frame.osr_loop_count >= OSR_LOOP_THRESHOLD
-                        && frame.bytecode_array.try_get_jit_code().is_none()
-                    {
-                        maybe_compile_baseline(&frame.bytecode_array);
-                    }
-                    if frame.osr_loop_count >= MAGLEV_OSR_LOOP_THRESHOLD {
-                        maybe_compile_maglev(&frame.bytecode_array);
-                    }
-                    if frame.osr_loop_count >= TURBOFAN_OSR_LOOP_THRESHOLD {
-                        maybe_compile_turbofan(&frame.bytecode_array);
-                    }
-                }
-                Opcode::JumpIfTrue => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfTrue", 0));
-                    };
-                    if matches!(frame.accumulator, JsValue::Boolean(true)) {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                Opcode::JumpIfFalse => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfFalse", 0));
-                    };
-                    if matches!(frame.accumulator, JsValue::Boolean(false)) {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                Opcode::JumpIfToBooleanTrue => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfToBooleanTrue", 0));
-                    };
-                    if frame.accumulator.to_boolean() {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                Opcode::JumpIfToBooleanFalse => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfToBooleanFalse", 0));
-                    };
-                    if !frame.accumulator.to_boolean() {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                Opcode::JumpIfNull => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfNull", 0));
-                    };
-                    if frame.accumulator.is_null() {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                Opcode::JumpIfNotNull => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfNotNull", 0));
-                    };
-                    if !frame.accumulator.is_null() {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                Opcode::JumpIfUndefined => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfUndefined", 0));
-                    };
-                    if frame.accumulator.is_undefined() {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                Opcode::JumpIfNotUndefined => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfNotUndefined", 0));
-                    };
-                    if !frame.accumulator.is_undefined() {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                Opcode::JumpIfUndefinedOrNull => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfUndefinedOrNull", 0));
-                    };
-                    if frame.accumulator.is_nullish() {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                Opcode::Return => {
-                    return Ok(frame.accumulator.clone());
-                }
-
-                // ── Closure creation ───────────────────────────────────────
-                // CreateClosure [func_idx, slot, flags]: load a BytecodeArray
-                // from the constant pool and wrap it as a callable function
-                // value.  The slot and flags operands are feedback-vector
-                // metadata and are ignored at runtime.
-                Opcode::CreateClosure => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("CreateClosure", 0));
-                    };
-                    let entry = frame.bytecode_array.get_constant(idx).ok_or_else(|| {
-                        StatorError::Internal(format!(
-                            "CreateClosure: constant pool index {idx} out of bounds"
-                        ))
-                    })?;
-                    let ConstantPoolEntry::Function(ba) = entry else {
-                        return Err(StatorError::Internal(
-                            "CreateClosure: constant pool entry is not a Function".into(),
-                        ));
-                    };
-                    frame.accumulator = JsValue::Function(Rc::new((**ba).clone()));
-                }
-
-                // ── Function calls ─────────────────────────────────────────
-                //
-                // Convention for all Call* opcodes:
-                //   – The callee register holds a JsValue::Function.
-                //   – If the function is a generator (`ba.is_generator()` is
-                //     true), a fresh GeneratorState is created and returned
-                //     as JsValue::Generator without executing the body.
-                //   – Otherwise, arguments are collected, a new frame is
-                //     created, and the interpreter runs the body.
-                //
-                // CallAnyReceiver [callable, args_start, args_count, slot]:
-                //   Plain call with undefined receiver.  args_start is the
-                //   first argument register; arguments occupy the next
-                //   args_count consecutive registers.
-                Opcode::CallAnyReceiver => {
-                    let Operand::Register(callee_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallAnyReceiver", 0));
-                    };
-                    let Operand::Register(args_start_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("CallAnyReceiver", 1));
-                    };
-                    let Operand::RegisterCount(arg_count) = instr.operands[2] else {
-                        return Err(err_bad_operand("CallAnyReceiver", 2));
-                    };
-                    let callee = frame.read_reg(callee_v)?.clone();
-                    match callee {
-                        JsValue::Function(ba) => {
-                            if ba.is_generator() {
-                                frame.accumulator =
-                                    JsValue::Generator(GeneratorState::new((*ba).clone()));
-                            } else if ba.is_async() {
-                                let args = collect_args(frame, args_start_v, arg_count)?;
-                                frame.accumulator =
-                                    Interpreter::run_async_function((*ba).clone(), args)?;
-                            } else {
-                                let args = collect_args(frame, args_start_v, arg_count)?;
-                                // ── Tiering ──────────────────────────────────
-                                let count = ba.increment_invocation_count();
-                                if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none() {
-                                    maybe_compile_baseline(&ba);
-                                }
-                                if count >= MAGLEV_TIERING_THRESHOLD {
-                                    maybe_compile_maglev(&ba);
-                                }
-                                if count >= TURBOFAN_TIERING_THRESHOLD {
-                                    maybe_compile_turbofan(&ba);
-                                }
-                                let mut tried_jit = false;
-                                if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
-                                    frame.accumulator = jit_result?;
-                                    tried_jit = true;
-                                }
-                                if !tried_jit {
-                                    let mut callee_frame = InterpreterFrame::new_with_globals(
-                                        (*ba).clone(),
-                                        args,
-                                        Rc::clone(&frame.global_env),
-                                    );
-                                    push_call_frame("<anonymous>")?;
-                                    let result = Interpreter::run(&mut callee_frame);
-                                    pop_call_frame();
-                                    frame.accumulator = result?;
-                                }
-                            }
-                        }
-                        JsValue::NativeFunction(f) => {
-                            let args = collect_args(frame, args_start_v, arg_count)?;
-                            frame.accumulator = f(args)?;
-                        }
-                        JsValue::PlainObject(ref map) => {
-                            if let Some(JsValue::NativeFunction(f)) =
-                                map.borrow().get("__call__").cloned()
-                            {
-                                let args = collect_args(frame, args_start_v, arg_count)?;
-                                frame.accumulator = f(args)?;
-                            } else {
-                                return Err(StatorError::TypeError(
-                                    "CallAnyReceiver: callee is not a function (got PlainObject)"
-                                        .to_string(),
-                                ));
-                            }
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "CallAnyReceiver: callee is not a function (got {other:?})"
-                            )));
-                        }
-                    }
-                }
-
-                // CallUndefinedReceiver0 [callable, slot]:
-                //   Call with undefined receiver and zero arguments.
-                Opcode::CallUndefinedReceiver0 => {
-                    let Operand::Register(callee_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallUndefinedReceiver0", 0));
-                    };
-                    let callee = frame.read_reg(callee_v)?.clone();
-                    match callee {
-                        JsValue::Function(ba) => {
-                            if ba.is_generator() {
-                                frame.accumulator =
-                                    JsValue::Generator(GeneratorState::new((*ba).clone()));
-                            } else if ba.is_async() {
-                                frame.accumulator =
-                                    Interpreter::run_async_function((*ba).clone(), vec![])?;
-                            } else {
-                                let args: Vec<JsValue> = vec![];
-                                let count = ba.increment_invocation_count();
-                                if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none() {
-                                    maybe_compile_baseline(&ba);
-                                }
-                                if count >= MAGLEV_TIERING_THRESHOLD {
-                                    maybe_compile_maglev(&ba);
-                                }
-                                if count >= TURBOFAN_TIERING_THRESHOLD {
-                                    maybe_compile_turbofan(&ba);
-                                }
-                                let mut tried_jit = false;
-                                if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
-                                    frame.accumulator = jit_result?;
-                                    tried_jit = true;
-                                }
-                                if !tried_jit {
-                                    let mut callee_frame = InterpreterFrame::new_with_globals(
-                                        (*ba).clone(),
-                                        args,
-                                        Rc::clone(&frame.global_env),
-                                    );
-                                    push_call_frame("<anonymous>")?;
-                                    let result = Interpreter::run(&mut callee_frame);
-                                    pop_call_frame();
-                                    frame.accumulator = result?;
-                                }
-                            }
-                        }
-                        JsValue::NativeFunction(f) => {
-                            frame.accumulator = f(vec![])?;
-                        }
-                        JsValue::PlainObject(ref map) => {
-                            if let Some(JsValue::NativeFunction(f)) =
-                                map.borrow().get("__call__").cloned()
-                            {
-                                frame.accumulator = f(vec![])?;
-                            } else {
-                                return Err(StatorError::TypeError(
-                                    "CallUndefinedReceiver0: callee is not a function (got PlainObject)".to_string()
-                                ));
-                            }
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "CallUndefinedReceiver0: callee is not a function (got {other:?})"
-                            )));
-                        }
-                    }
-                }
-
-                // CallUndefinedReceiver1 [callable, arg1, slot]:
-                //   Call with undefined receiver and one argument.
-                Opcode::CallUndefinedReceiver1 => {
-                    let Operand::Register(callee_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallUndefinedReceiver1", 0));
-                    };
-                    let Operand::Register(arg1_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("CallUndefinedReceiver1", 1));
-                    };
-                    let callee = frame.read_reg(callee_v)?.clone();
-                    match callee {
-                        JsValue::Function(ba) => {
-                            if ba.is_generator() {
-                                frame.accumulator =
-                                    JsValue::Generator(GeneratorState::new((*ba).clone()));
-                            } else if ba.is_async() {
-                                let arg1 = frame.read_reg(arg1_v)?.clone();
-                                frame.accumulator =
-                                    Interpreter::run_async_function((*ba).clone(), vec![arg1])?;
-                            } else {
-                                let arg1 = frame.read_reg(arg1_v)?.clone();
-                                let args = vec![arg1];
-                                let count = ba.increment_invocation_count();
-                                if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none() {
-                                    maybe_compile_baseline(&ba);
-                                }
-                                if count >= MAGLEV_TIERING_THRESHOLD {
-                                    maybe_compile_maglev(&ba);
-                                }
-                                if count >= TURBOFAN_TIERING_THRESHOLD {
-                                    maybe_compile_turbofan(&ba);
-                                }
-                                let mut tried_jit = false;
-                                if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
-                                    frame.accumulator = jit_result?;
-                                    tried_jit = true;
-                                }
-                                if !tried_jit {
-                                    let mut callee_frame = InterpreterFrame::new_with_globals(
-                                        (*ba).clone(),
-                                        args,
-                                        Rc::clone(&frame.global_env),
-                                    );
-                                    push_call_frame("<anonymous>")?;
-                                    let result = Interpreter::run(&mut callee_frame);
-                                    pop_call_frame();
-                                    frame.accumulator = result?;
-                                }
-                            }
-                        }
-                        JsValue::NativeFunction(f) => {
-                            let arg1 = frame.read_reg(arg1_v)?.clone();
-                            frame.accumulator = f(vec![arg1])?;
-                        }
-                        JsValue::PlainObject(ref map) => {
-                            if let Some(JsValue::NativeFunction(f)) =
-                                map.borrow().get("__call__").cloned()
-                            {
-                                let arg1 = frame.read_reg(arg1_v)?.clone();
-                                frame.accumulator = f(vec![arg1])?;
-                            } else {
-                                return Err(StatorError::TypeError(
-                                    "CallUndefinedReceiver1: callee is not a function (got PlainObject)".to_string()
-                                ));
-                            }
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "CallUndefinedReceiver1: callee is not a function (got {other:?})"
-                            )));
-                        }
-                    }
-                }
-
-                // CallUndefinedReceiver2 [callable, arg1, arg2, slot]:
-                //   Call with undefined receiver and two arguments.
-                Opcode::CallUndefinedReceiver2 => {
-                    let Operand::Register(callee_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallUndefinedReceiver2", 0));
-                    };
-                    let Operand::Register(arg1_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("CallUndefinedReceiver2", 1));
-                    };
-                    let Operand::Register(arg2_v) = instr.operands[2] else {
-                        return Err(err_bad_operand("CallUndefinedReceiver2", 2));
-                    };
-                    let callee = frame.read_reg(callee_v)?.clone();
-                    match callee {
-                        JsValue::Function(ba) => {
-                            if ba.is_generator() {
-                                frame.accumulator =
-                                    JsValue::Generator(GeneratorState::new((*ba).clone()));
-                            } else if ba.is_async() {
-                                let arg1 = frame.read_reg(arg1_v)?.clone();
-                                let arg2 = frame.read_reg(arg2_v)?.clone();
-                                frame.accumulator = Interpreter::run_async_function(
-                                    (*ba).clone(),
-                                    vec![arg1, arg2],
-                                )?;
-                            } else {
-                                let arg1 = frame.read_reg(arg1_v)?.clone();
-                                let arg2 = frame.read_reg(arg2_v)?.clone();
-                                let args = vec![arg1, arg2];
-                                // ── Tiering ──────────────────────────────────
-                                let count = ba.increment_invocation_count();
-                                if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none() {
-                                    maybe_compile_baseline(&ba);
-                                }
-                                if count >= MAGLEV_TIERING_THRESHOLD {
-                                    maybe_compile_maglev(&ba);
-                                }
-                                if count >= TURBOFAN_TIERING_THRESHOLD {
-                                    maybe_compile_turbofan(&ba);
-                                }
-                                let mut tried_jit = false;
-                                if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
-                                    frame.accumulator = jit_result?;
-                                    tried_jit = true;
-                                }
-                                if !tried_jit {
-                                    let mut callee_frame = InterpreterFrame::new_with_globals(
-                                        (*ba).clone(),
-                                        args,
-                                        Rc::clone(&frame.global_env),
-                                    );
-                                    push_call_frame("<anonymous>")?;
-                                    let result = Interpreter::run(&mut callee_frame);
-                                    pop_call_frame();
-                                    frame.accumulator = result?;
-                                }
-                            }
-                        }
-                        JsValue::NativeFunction(f) => {
-                            let arg1 = frame.read_reg(arg1_v)?.clone();
-                            let arg2 = frame.read_reg(arg2_v)?.clone();
-                            frame.accumulator = f(vec![arg1, arg2])?;
-                        }
-                        JsValue::PlainObject(ref map) => {
-                            if let Some(JsValue::NativeFunction(f)) =
-                                map.borrow().get("__call__").cloned()
-                            {
-                                let arg1 = frame.read_reg(arg1_v)?.clone();
-                                let arg2 = frame.read_reg(arg2_v)?.clone();
-                                frame.accumulator = f(vec![arg1, arg2])?;
-                            } else {
-                                return Err(StatorError::TypeError(
-                                    "CallUndefinedReceiver2: callee is not a function (got PlainObject)".to_string()
-                                ));
-                            }
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "CallUndefinedReceiver2: callee is not a function (got {other:?})"
-                            )));
-                        }
-                    }
-                }
-
-                // CallProperty [callable, recv, args_count, slot]:
-                //   Method call.  The receiver ("this") is in the register
-                //   immediately before the callee register in the register
-                //   file.  Arguments occupy the args_count consecutive
-                //   registers starting one past the callee register.
-                //   The receiver is stored in the callee frame's context so
-                //   that the callee can read it if needed.
-                Opcode::CallProperty => {
-                    let Operand::Register(callee_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallProperty", 0));
-                    };
-                    let Operand::Register(recv_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("CallProperty", 1));
-                    };
-                    let Operand::RegisterCount(arg_count) = instr.operands[2] else {
-                        return Err(err_bad_operand("CallProperty", 2));
-                    };
-                    let callee = frame.read_reg(callee_v)?.clone();
-                    // Arguments reside in the registers immediately following
-                    // the callee register in the flat register file.
-                    let callee_flat = frame.reg_index(callee_v)?;
-                    let args = (0..arg_count as usize)
-                        .map(|i| frame.registers[callee_flat + 1 + i].clone())
-                        .collect::<Vec<_>>();
-                    match callee {
-                        JsValue::Function(ba) => {
-                            let this_val = frame.read_reg(recv_v)?.clone();
-                            // ── Tiering ──────────────────────────────────────
-                            let count = ba.increment_invocation_count();
-                            if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none() {
-                                maybe_compile_baseline(&ba);
-                            }
-                            if count >= MAGLEV_TIERING_THRESHOLD {
-                                maybe_compile_maglev(&ba);
-                            }
-                            if count >= TURBOFAN_TIERING_THRESHOLD {
-                                maybe_compile_turbofan(&ba);
-                            }
-                            let mut tried_jit = false;
-                            if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
-                                frame.accumulator = jit_result?;
-                                tried_jit = true;
-                            }
-                            if !tried_jit {
-                                let mut callee_frame = InterpreterFrame::new_with_globals(
-                                    (*ba).clone(),
-                                    args,
-                                    Rc::clone(&frame.global_env),
-                                );
-                                callee_frame.context = Some(this_val);
-                                push_call_frame("<anonymous>")?;
-                                let result = Interpreter::run(&mut callee_frame);
-                                pop_call_frame();
-                                frame.accumulator = result?;
-                            }
-                        }
-                        JsValue::NativeFunction(f) => {
-                            frame.accumulator = f(args)?;
-                        }
-                        JsValue::PlainObject(ref map) => {
-                            if let Some(JsValue::NativeFunction(f)) =
-                                map.borrow().get("__call__").cloned()
-                            {
-                                frame.accumulator = f(args)?;
-                            } else {
-                                return Err(StatorError::TypeError(
-                                    "CallProperty: callee is not a function (got PlainObject)"
-                                        .to_string(),
-                                ));
-                            }
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "CallProperty: callee is not a function (got {other:?})"
-                            )));
-                        }
-                    }
-                }
-
-                // CallWithSpread [callable, args_start, args_count, slot]:
-                //   Call with a spread argument.  For the interpreter's
-                //   purposes we treat this identically to CallAnyReceiver;
-                //   the spread expansion has already been resolved by the
-                //   compiler into the argument registers.
-                Opcode::CallWithSpread => {
-                    let Operand::Register(callee_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallWithSpread", 0));
-                    };
-                    let Operand::Register(args_start_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("CallWithSpread", 1));
-                    };
-                    let Operand::RegisterCount(arg_count) = instr.operands[2] else {
-                        return Err(err_bad_operand("CallWithSpread", 2));
-                    };
-                    let callee = frame.read_reg(callee_v)?.clone();
-                    match callee {
-                        JsValue::Function(ba) => {
-                            let args = collect_args(frame, args_start_v, arg_count)?;
-                            // ── Tiering ──────────────────────────────────────
-                            let count = ba.increment_invocation_count();
-                            if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none() {
-                                maybe_compile_baseline(&ba);
-                            }
-                            if count >= MAGLEV_TIERING_THRESHOLD {
-                                maybe_compile_maglev(&ba);
-                            }
-                            if count >= TURBOFAN_TIERING_THRESHOLD {
-                                maybe_compile_turbofan(&ba);
-                            }
-                            let mut tried_jit = false;
-                            if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
-                                frame.accumulator = jit_result?;
-                                tried_jit = true;
-                            }
-                            if !tried_jit {
-                                let mut callee_frame = InterpreterFrame::new_with_globals(
-                                    (*ba).clone(),
-                                    args,
-                                    Rc::clone(&frame.global_env),
-                                );
-                                push_call_frame("<anonymous>")?;
-                                let result = Interpreter::run(&mut callee_frame);
-                                pop_call_frame();
-                                frame.accumulator = result?;
-                            }
-                        }
-                        JsValue::NativeFunction(f) => {
-                            let args = collect_args(frame, args_start_v, arg_count)?;
-                            frame.accumulator = f(args)?;
-                        }
-                        JsValue::PlainObject(ref map) => {
-                            if let Some(JsValue::NativeFunction(f)) =
-                                map.borrow().get("__call__").cloned()
-                            {
-                                let args = collect_args(frame, args_start_v, arg_count)?;
-                                frame.accumulator = f(args)?;
-                            } else {
-                                return Err(StatorError::TypeError(
-                                    "CallWithSpread: callee is not a function (got PlainObject)"
-                                        .to_string(),
-                                ));
-                            }
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "CallWithSpread: callee is not a function (got {other:?})"
-                            )));
-                        }
-                    }
-                }
-
-                // ── Construct ──────────────────────────────────────────────
-                //
-                // Construct [constructor, args_start, args_count, slot]:
-                //   `new constructor(args…)`.  Executes the constructor body
-                //   and wires `[[Prototype]]` on the resulting object.
-                Opcode::Construct | Opcode::ConstructWithSpread => {
-                    let Operand::Register(ctor_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("Construct", 0));
-                    };
-                    let Operand::Register(args_start_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("Construct", 1));
-                    };
-                    let Operand::RegisterCount(arg_count) = instr.operands[2] else {
-                        return Err(err_bad_operand("Construct", 2));
-                    };
-                    let ctor = frame.read_reg(ctor_v)?.clone();
-                    // Resolve constructor's "prototype" for [[Prototype]] wiring.
-                    let ctor_proto = proto_lookup(&ctor, "prototype");
-                    match ctor {
-                        JsValue::Function(ba) => {
-                            let args = collect_args(frame, args_start_v, arg_count)?;
-                            let mut callee_frame = InterpreterFrame::new_with_globals(
-                                (*ba).clone(),
-                                args,
-                                Rc::clone(&frame.global_env),
-                            );
-                            push_call_frame("<anonymous>")?;
-                            let result = Interpreter::run(&mut callee_frame);
-                            pop_call_frame();
-                            let val = result?;
-                            frame.accumulator = wire_construct_prototype(val, &ctor_proto);
-                        }
-                        JsValue::NativeFunction(f) => {
-                            let args = collect_args(frame, args_start_v, arg_count)?;
-                            frame.accumulator = f(args)?;
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "Construct: constructor is not a function (got {other:?})"
-                            )));
-                        }
-                    }
-                }
-
-                // ── Context management ─────────────────────────────────────
-                //
-                // PushContext [reg]: the accumulator holds the new context
-                //   value; the old context is saved into `reg` so it can be
-                //   restored later by PopContext.
-                //
-                //   Registers hold `JsValue`, not `Option<JsValue>`, so an
-                //   absent context is encoded as `JsValue::Undefined` in the
-                //   saved register.  PopContext inverts this by mapping
-                //   `Undefined` back to `None`.
-                Opcode::PushContext => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("PushContext", 0));
-                    };
-                    // Encode None as Undefined so it can be stored in a register.
-                    let old_ctx = frame.context.take().unwrap_or(JsValue::Undefined);
-                    frame.write_reg(v, old_ctx)?;
-                    frame.context = Some(frame.accumulator.clone());
-                }
-
-                // PopContext [reg]: restore the context that was previously
-                //   saved in `reg` by PushContext.
-                //   `Undefined` in the register means there was no context.
-                Opcode::PopContext => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("PopContext", 0));
-                    };
-                    let saved = frame.read_reg(v)?.clone();
-                    frame.context = if saved.is_undefined() {
-                        None
-                    } else {
-                        Some(saved)
-                    };
-                }
-
-                // ── Context slot access ────────────────────────────────────
-                //
-                // LdaContextSlot [ctx_reg, slot_idx, depth]:
-                //   Load the value from `context[slot_idx]` after walking
-                //   `depth` levels up the context chain starting from the
-                //   context in `ctx_reg`.
-                Opcode::LdaContextSlot | Opcode::LdaImmutableContextSlot => {
-                    let Operand::Register(ctx_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaContextSlot", 0));
-                    };
-                    let Operand::ConstantPoolIdx(slot_idx) = instr.operands[1] else {
-                        return Err(err_bad_operand("LdaContextSlot", 1));
-                    };
-                    let Operand::Immediate(depth) = instr.operands[2] else {
-                        return Err(err_bad_operand("LdaContextSlot", 2));
-                    };
-                    let ctx_val = frame.read_reg(ctx_v)?.clone();
-                    let ctx = extract_context(&ctx_val, "LdaContextSlot")?;
-                    let target = walk_context_chain(&ctx, depth as u32, "LdaContextSlot")?;
-                    let borrowed = target.borrow();
-                    let slot = slot_idx as usize;
-                    frame.accumulator = borrowed
-                        .slots
-                        .get(slot)
-                        .cloned()
-                        .unwrap_or(JsValue::Undefined);
-                }
-
-                // LdaCurrentContextSlot [slot_idx]:
-                //   Shorthand for LdaContextSlot with depth=0, using the
-                //   frame's current context.
-                Opcode::LdaCurrentContextSlot | Opcode::LdaImmutableCurrentContextSlot => {
-                    let Operand::ConstantPoolIdx(slot_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaCurrentContextSlot", 0));
-                    };
-                    let ctx_val = frame
-                        .context
-                        .as_ref()
-                        .ok_or_else(|| {
-                            StatorError::Internal("LdaCurrentContextSlot: no active context".into())
-                        })?
-                        .clone();
-                    let ctx = extract_context(&ctx_val, "LdaCurrentContextSlot")?;
-                    let borrowed = ctx.borrow();
-                    let slot = slot_idx as usize;
-                    frame.accumulator = borrowed
-                        .slots
-                        .get(slot)
-                        .cloned()
-                        .unwrap_or(JsValue::Undefined);
-                }
-
-                // StaContextSlot [ctx_reg, slot_idx, depth]:
-                //   Store the accumulator into `context[slot_idx]` after
-                //   walking `depth` levels up the context chain.
-                Opcode::StaContextSlot => {
-                    let Operand::Register(ctx_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("StaContextSlot", 0));
-                    };
-                    let Operand::ConstantPoolIdx(slot_idx) = instr.operands[1] else {
-                        return Err(err_bad_operand("StaContextSlot", 1));
-                    };
-                    let Operand::Immediate(depth) = instr.operands[2] else {
-                        return Err(err_bad_operand("StaContextSlot", 2));
-                    };
-                    let ctx_val = frame.read_reg(ctx_v)?.clone();
-                    let ctx = extract_context(&ctx_val, "StaContextSlot")?;
-                    let target = walk_context_chain(&ctx, depth as u32, "StaContextSlot")?;
-                    let mut borrowed = target.borrow_mut();
-                    let slot = slot_idx as usize;
-                    if slot >= borrowed.slots.len() {
-                        borrowed.slots.resize(slot + 1, JsValue::Undefined);
-                    }
-                    borrowed.slots[slot] = frame.accumulator.clone();
-                }
-
-                // StaCurrentContextSlot [slot_idx]:
-                //   Shorthand for StaContextSlot with depth=0.
-                Opcode::StaCurrentContextSlot => {
-                    let Operand::ConstantPoolIdx(slot_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("StaCurrentContextSlot", 0));
-                    };
-                    let ctx_val = frame
-                        .context
-                        .as_ref()
-                        .ok_or_else(|| {
-                            StatorError::Internal("StaCurrentContextSlot: no active context".into())
-                        })?
-                        .clone();
-                    let ctx = extract_context(&ctx_val, "StaCurrentContextSlot")?;
-                    let mut borrowed = ctx.borrow_mut();
-                    let slot = slot_idx as usize;
-                    if slot >= borrowed.slots.len() {
-                        borrowed.slots.resize(slot + 1, JsValue::Undefined);
-                    }
-                    borrowed.slots[slot] = frame.accumulator.clone();
-                }
-
-                // ── Context construction ───────────────────────────────────
-                //
-                // CreateFunctionContext [scope_idx, slot_count]:
-                //   Create a new context with `slot_count` slots for a
-                //   function scope.  The current frame context (if any)
-                //   becomes the parent.  The new context is placed in the
-                //   accumulator but is NOT automatically installed — the
-                //   caller typically follows with `PushContext`.
-                Opcode::CreateFunctionContext => {
-                    let Operand::Immediate(slot_count) = instr.operands[1] else {
-                        return Err(err_bad_operand("CreateFunctionContext", 1));
-                    };
-                    let parent = match &frame.context {
-                        Some(JsValue::Context(ctx)) => Some(Rc::clone(ctx)),
-                        _ => None,
-                    };
-                    let ctx = JsContext::new(slot_count as usize, parent);
-                    frame.accumulator = JsValue::Context(ctx);
-                }
-
-                // CreateBlockContext [scope_idx]:
-                //   Create a new context for a block scope.  Like
-                //   CreateFunctionContext but the slot count is not encoded
-                //   in the operand — we default to 0 slots and let
-                //   StaContextSlot grow them on demand.
-                Opcode::CreateBlockContext => {
-                    let parent = match &frame.context {
-                        Some(JsValue::Context(ctx)) => Some(Rc::clone(ctx)),
-                        _ => None,
-                    };
-                    let ctx = JsContext::new(0, parent);
-                    frame.accumulator = JsValue::Context(ctx);
-                }
-
-                // CreateEvalContext [scope_idx, slot_count]:
-                //   Create a new context for an eval scope.
-                Opcode::CreateEvalContext => {
-                    let Operand::Immediate(slot_count) = instr.operands[1] else {
-                        return Err(err_bad_operand("CreateEvalContext", 1));
-                    };
-                    let parent = match &frame.context {
-                        Some(JsValue::Context(ctx)) => Some(Rc::clone(ctx)),
-                        _ => None,
-                    };
-                    let ctx = JsContext::new(slot_count as usize, parent);
-                    frame.accumulator = JsValue::Context(ctx);
-                }
-
-                // CreateCatchContext [exception_reg, scope_idx]:
-                //   Create a new context for a catch block, with the caught
-                //   exception as slot 0.
-                Opcode::CreateCatchContext => {
-                    let Operand::Register(exc_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CreateCatchContext", 0));
-                    };
-                    let exception = frame.read_reg(exc_v)?.clone();
-                    let parent = match &frame.context {
-                        Some(JsValue::Context(ctx)) => Some(Rc::clone(ctx)),
-                        _ => None,
-                    };
-                    let ctx = JsContext::new(1, parent);
-                    ctx.borrow_mut().slots[0] = exception;
-                    frame.accumulator = JsValue::Context(ctx);
-                }
-
-                // CreateWithContext [obj_reg, scope_idx]:
-                //   Create a new context for a `with` statement.  The
-                //   object is stored as slot 0 of the new context.
-                Opcode::CreateWithContext => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CreateWithContext", 0));
-                    };
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    let parent = match &frame.context {
-                        Some(JsValue::Context(ctx)) => Some(Rc::clone(ctx)),
-                        _ => None,
-                    };
-                    let ctx = JsContext::new(1, parent);
-                    ctx.borrow_mut().slots[0] = obj;
-                    frame.accumulator = JsValue::Context(ctx);
-                }
-
-                // ── Exception handling ─────────────────────────────────────
-                //
-                // Throw / ReThrow: the value to throw is in the accumulator.
-                // Walk the handler table looking for the innermost entry whose
-                // [try_start, try_end) range covers the current instruction
-                // (pc was already incremented, so the throwing instruction
-                // index is `frame.pc - 1`).  If a handler is found, load
-                // the thrown value into the accumulator and jump to the
-                // handler entry point.  Otherwise, propagate the exception
-                // as a `StatorError::JsException` to the caller.
-                Opcode::Throw | Opcode::ReThrow => {
-                    let thrown = frame.accumulator.clone();
-                    let throw_idx = (frame.pc - 1) as u32;
-                    if let Some(handler_pc) = find_handler(throw_idx, &handler_table) {
-                        frame.accumulator = thrown;
-                        frame.pc = handler_pc;
-                        continue;
-                    }
-                    // ── pause-on-exceptions ───────────────────────────────
-                    // When a debugger is attached with pause_on_exceptions
-                    // enabled, suspend execution *before* the exception
-                    // propagates.  Back up the program counter to the Throw
-                    // instruction so that resuming re-executes it and lets the
-                    // exception propagate normally (skip_next prevents a
-                    // double-pause on the re-execution).
-                    let throw_offset = byte_offsets[throw_idx as usize] as u32;
-                    if let Some(pause_err) = ACTIVE_DEBUGGER.with(|d| {
-                        let opt = d.borrow();
-                        opt.as_ref().and_then(|rc| {
-                            let mut dbg = rc.borrow_mut();
-                            // consume_exception_resume returns true on a
-                            // resume re-execution — skip the pause in that
-                            // case so the exception can propagate.
-                            if dbg.pause_on_exceptions && !dbg.consume_exception_resume() {
-                                frame.pc = throw_idx as usize; // back up
-                                Some(dbg.on_exception(throw_offset))
-                            } else {
-                                None
-                            }
-                        })
-                    }) {
-                        return Err(pause_err);
-                    }
-                    // No handler in this frame — serialise the thrown value and
-                    // propagate it as a `StatorError::JsException` to the caller.
-                    let msg = error_message_from_value(&thrown);
-                    return Err(StatorError::JsException(msg));
-                }
-
-                // ── Ignored no-ops ─────────────────────────────────────────
-                // These opcodes carry metadata that does not affect execution.
-                Opcode::StackCheck
-                | Opcode::SetExpressionPosition
-                | Opcode::SetExpressionPositionFromEnd => {}
-
-                // ── Global variable access ──────────────────────────────────
-                //
-                // LdaGlobal [name_idx, feedback_slot]:
-                //   Load the global variable named by the string at
-                //   `constant_pool[name_idx]` into the accumulator.
-                //   Produces `undefined` when the name is not found.
-                Opcode::LdaGlobal | Opcode::LdaGlobalInsideTypeof => {
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaGlobal", 0));
-                    };
-                    let name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "LdaGlobal: constant is not a string".into(),
-                            ));
-                        }
-                    };
-                    frame.accumulator = frame
-                        .global_env
-                        .borrow()
-                        .get(&name)
-                        .cloned()
-                        .unwrap_or(JsValue::Undefined);
-                }
-
-                // StaGlobal [name_idx, feedback_slot]:
-                //   Store the accumulator to the global variable named by
-                //   `constant_pool[name_idx]`.
-                Opcode::StaGlobal => {
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("StaGlobal", 0));
-                    };
-                    let name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "StaGlobal: constant is not a string".into(),
-                            ));
-                        }
-                    };
-                    let val = frame.accumulator.clone();
-                    frame.global_env.borrow_mut().insert(name, val);
-                }
-
-                // LdaNamedProperty [object_reg, name_idx, feedback_slot]:
-                //   Load the named property from the object in `object_reg`.
-                //   Supports `PlainObject` (property map) and falls back to
-                //   `undefined` for other value types.
-                Opcode::LdaNamedProperty => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaNamedProperty", 0));
-                    };
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[1] else {
-                        return Err(err_bad_operand("LdaNamedProperty", 1));
-                    };
-                    let prop_name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "LdaNamedProperty: property name is not a string".into(),
-                            ));
-                        }
-                    };
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    frame.accumulator = proto_lookup(&obj, &prop_name);
-                }
-
-                // StaNamedProperty [object_reg, name_idx, feedback_slot]:
-                //   Store the accumulator into the named property on the object
-                //   held in `object_reg`.  Supports `PlainObject` (property
-                //   map); stores to other value types are silently discarded.
-                //   The accumulator is unchanged (assignment returns its RHS).
-                Opcode::StaNamedProperty => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("StaNamedProperty", 0));
-                    };
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[1] else {
-                        return Err(err_bad_operand("StaNamedProperty", 1));
-                    };
-                    let prop_name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "StaNamedProperty: property name is not a string".into(),
-                            ));
-                        }
-                    };
-                    let val = frame.accumulator.clone();
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    if let JsValue::PlainObject(ref map) = obj {
-                        map.borrow_mut().insert(prop_name, val);
-                    }
-                    // Accumulator stays unchanged: the assignment's completion
-                    // value is the stored value (already in the accumulator).
-                }
-
-                // LdaKeyedProperty [object_reg, feedback_slot]:
-                //   Load the keyed property from the object in `object_reg`.
-                //   The key is in the accumulator.
-                //   Supports PlainObject (string keys), Array (integer keys),
-                //   and String (character-at-index).  Falls back to
-                //   `undefined` for other types or missing properties.
-                Opcode::LdaKeyedProperty => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaKeyedProperty", 0));
-                    };
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    let key = frame.accumulator.clone();
-                    frame.accumulator = keyed_load(&obj, &key)?;
-                }
-
-                // StaKeyedProperty [object_reg, key_reg, feedback_slot]:
-                //   Store the accumulator into the keyed property on the
-                //   object held in `object_reg`.  The key is in `key_reg`.
-                //   Supports PlainObject (string keys) and Array (integer
-                //   indices via PlainObject).  Stores to other value types
-                //   are silently discarded.
-                //   The accumulator is unchanged (assignment returns its RHS).
-                Opcode::StaKeyedProperty => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("StaKeyedProperty", 0));
-                    };
-                    let Operand::Register(key_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("StaKeyedProperty", 1));
-                    };
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    let key = frame.read_reg(key_v)?.clone();
-                    let val = frame.accumulator.clone();
-                    keyed_store(&obj, &key, val)?;
-                    // Accumulator stays unchanged.
-                }
-
-                //
-                // GetIterator [iterable_reg, load_slot, call_slot]:
-                //   Obtain a sync iterator from the iterable in `iterable_reg`.
-                //
-                //   Supported iterables:
-                //   - JsValue::Array   → NativeIterator over the array elements
-                //   - JsValue::String  → NativeIterator over Unicode characters
-                //   - JsValue::Generator → generators are their own iterators
-                //   - JsValue::Iterator → pass through unchanged
-                //
-                //   The result is placed in the accumulator.
-                Opcode::GetIterator => {
-                    let Operand::Register(iter_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("GetIterator", 0));
-                    };
-                    let iterable = frame.read_reg(iter_v)?.clone();
-                    frame.accumulator = match iterable {
-                        JsValue::Array(items) => {
-                            let items_vec: Vec<JsValue> = (*items).clone();
-                            JsValue::Iterator(NativeIterator::from_items(items_vec))
-                        }
-                        JsValue::String(ref s) => JsValue::Iterator(NativeIterator::from_string(s)),
-                        // Generators and existing iterators pass through unchanged.
-                        JsValue::Generator(_) | JsValue::Iterator(_) => iterable,
-                        // PlainObject with @@iterator → call it to get the iterator.
-                        JsValue::PlainObject(ref map)
-                            if map.borrow().contains_key("@@iterator") =>
-                        {
-                            let iter_fn = map.borrow().get("@@iterator").cloned();
-                            if let Some(JsValue::NativeFunction(f)) = iter_fn {
-                                f(vec![])?
-                            } else {
-                                return Err(StatorError::TypeError(
-                                    "GetIterator: @@iterator is not a function".into(),
-                                ));
-                            }
-                        }
-                        // PlainObject with a "length" property → array-like.
-                        JsValue::PlainObject(ref map) if map.borrow().contains_key("length") => {
-                            let items = plain_object_to_array_items(map);
-                            JsValue::Iterator(NativeIterator::from_items(items))
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "GetIterator: value is not iterable (got {other:?})"
-                            )));
-                        }
-                    };
-                }
-
-                // GetAsyncIterator [iterable_reg, load_slot, call_slot]:
-                //   Async variant — behaves identically to GetIterator for all
-                //   currently-supported iterable types.
-                Opcode::GetAsyncIterator => {
-                    let Operand::Register(iter_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("GetAsyncIterator", 0));
-                    };
-                    let iterable = frame.read_reg(iter_v)?.clone();
-                    frame.accumulator = match iterable {
-                        JsValue::Array(items) => {
-                            let items_vec: Vec<JsValue> = (*items).clone();
-                            JsValue::Iterator(NativeIterator::from_items(items_vec))
-                        }
-                        JsValue::String(ref s) => JsValue::Iterator(NativeIterator::from_string(s)),
-                        JsValue::Generator(_) | JsValue::Iterator(_) => iterable,
-                        // PlainObject with @@iterator → call it to get the iterator.
-                        JsValue::PlainObject(ref map)
-                            if map.borrow().contains_key("@@iterator") =>
-                        {
-                            let iter_fn = map.borrow().get("@@iterator").cloned();
-                            if let Some(JsValue::NativeFunction(f)) = iter_fn {
-                                f(vec![])?
-                            } else {
-                                return Err(StatorError::TypeError(
-                                    "GetAsyncIterator: @@iterator is not a function".into(),
-                                ));
-                            }
-                        }
-                        JsValue::PlainObject(ref map) if map.borrow().contains_key("length") => {
-                            let items = plain_object_to_array_items(map);
-                            JsValue::Iterator(NativeIterator::from_items(items))
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "GetAsyncIterator: value is not iterable (got {other:?})"
-                            )));
-                        }
-                    };
-                }
-
-                // IteratorNext [iterator_reg, value_out_reg]:
-                //   Advance the iterator stored in `iterator_reg` by one step.
-                //
-                //   Semantics:
-                //   - `value_out_reg ← next value` (or `undefined` when done)
-                //   - `acc ← done` (a `JsValue::Boolean`)
-                //
-                //   Supported iterator types:
-                //   - JsValue::Iterator (NativeIterator)
-                //   - JsValue::Generator (runs one generator step via
-                //     `run_generator_step`)
-                Opcode::IteratorNext => {
-                    let Operand::Register(iter_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("IteratorNext", 0));
-                    };
-                    let Operand::Register(value_out_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("IteratorNext", 1));
-                    };
-                    let iter = frame.read_reg(iter_v)?.clone();
-                    let (value, done) = match iter {
-                        JsValue::Iterator(ni) => match ni.borrow_mut().next_item() {
-                            Some(v) => (v, false),
-                            None => (JsValue::Undefined, true),
-                        },
-                        JsValue::Generator(ref gs) => {
-                            match Interpreter::run_generator_step(gs, JsValue::Undefined)? {
-                                GeneratorStep::Yield(v) => (v, false),
-                                GeneratorStep::Return(v) => (v, true),
-                            }
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "IteratorNext: value is not an iterator (got {other:?})"
-                            )));
-                        }
-                    };
-                    frame.write_reg(value_out_v, value)?;
-                    frame.accumulator = JsValue::Boolean(done);
-                }
-
-                // ── Generators / Async ─────────────────────────────────────
-                //
-                // SuspendGenerator [gen, regs_start, regs_count, suspend_id]:
-                //   Yield a value from a generator function.
-                //
-                //   The yield value is whatever is currently in the accumulator.
-                //   When a generator_state is attached to the frame, the full
-                //   register file is saved back into it and the resume PC is
-                //   recorded so execution can continue from after this instruction
-                //   on the next call to `run_generator_step`.  The yielded value is
-                //   signalled to `run_generator_step` via `frame.suspend_result`,
-                //   then the interpreter loop exits early.
-                Opcode::SuspendGenerator => {
-                    let yield_val = frame.accumulator.clone();
-
-                    // Save state into the attached GeneratorState (if any).
-                    if let Some(gs_rc) = frame.generator_state.as_ref() {
-                        let mut gs = gs_rc.borrow_mut();
-                        // Save the full register file so that ResumeGenerator
-                        // can restore it on the next step.
-                        gs.registers.clone_from(&frame.registers);
-                        // frame.pc was already advanced past this instruction.
-                        gs.resume_pc = frame.pc;
-                        gs.status = GeneratorStatus::SuspendedAtYield;
-                    }
-
-                    frame.suspend_result = Some(yield_val.clone());
-                    return Ok(yield_val);
-                }
-
-                // ResumeGenerator [gen, regs_start, regs_count]:
-                //   Restore the register file from the generator state saved by a
-                //   prior SuspendGenerator.  The accumulator is left untouched: it
-                //   already holds the value sent by the caller of `.next(value)`.
-                Opcode::ResumeGenerator => {
-                    if let Some(gs_rc) = frame.generator_state.as_ref() {
-                        let mut gs = gs_rc.borrow_mut();
-                        // Restore the saved registers into the frame.
-                        // The saved register file has the same length as the frame
-                        // (set by SuspendGenerator from frame.registers.clone()), so
-                        // the min() only protects against a fresh generator where
-                        // gs.registers is empty (resume_pc == 0).
-                        let count = gs.registers.len().min(frame.registers.len());
-                        frame.registers[..count].clone_from_slice(&gs.registers[..count]);
-                        gs.status = GeneratorStatus::Executing;
-                    }
-                    // Accumulator keeps the resume value supplied by run_generator_step.
-                }
-
-                // GetGeneratorState [gen]:
-                //   Load the generator's lifecycle state as a Smi into the
-                //   accumulator.  Encoding: Executing=−2, Completed=−1,
-                //   SuspendedAtStart=0, SuspendedAtYield=1.
-                Opcode::GetGeneratorState => {
-                    frame.accumulator = if let Some(gs_rc) = frame.generator_state.as_ref() {
-                        JsValue::Smi(gs_rc.borrow().status.to_smi())
-                    } else {
-                        JsValue::Smi(GeneratorStatus::Completed.to_smi())
-                    };
-                }
-
-                // SetGeneratorState [gen]:
-                //   Write the Smi in the accumulator back to the generator's state.
-                Opcode::SetGeneratorState => {
-                    if let Some(gs_rc) = frame.generator_state.as_ref()
-                        && let JsValue::Smi(n) = frame.accumulator
-                    {
-                        gs_rc.borrow_mut().status = GeneratorStatus::from_smi(n);
-                    }
-                }
-
-                // SwitchOnGeneratorState [gen]:
-                //   At the beginning of a generator function, dispatch execution to
-                //   the saved resume point when the generator has been previously
-                //   suspended.  If the generator is fresh (resume_pc == 0), fall
-                //   through to the next instruction (start of the function body).
-                //
-                //   Note: when called via `run_generator_step`, the frame's PC is
-                //   already set to `resume_pc`, so this instruction only fires on
-                //   the first call (when resume_pc == 0) and falls through.  It
-                //   becomes useful when the generator bytecode is always entered
-                //   from PC 0 (the V8 pattern).
-                Opcode::SwitchOnGeneratorState => {
-                    if let Some(gs_rc) = frame.generator_state.as_ref() {
-                        let resume_pc = gs_rc.borrow().resume_pc;
-                        if resume_pc > 0 {
-                            frame.pc = resume_pc;
-                        }
-                    }
-                }
-
-                // ── Debugger statement ─────────────────────────────────────
-                //
-                // Debugger []:
-                //   Trigger a debugger breakpoint when a debugger is attached.
-                //   When no debugger is active, this instruction is a no-op.
-                //   The program counter has already been advanced past this
-                //   instruction, so the pause fires *after* the statement.
-                Opcode::Debugger => {
-                    let stmt_offset = byte_offsets[frame.pc - 1] as u32;
-                    if let Some(pause_err) = ACTIVE_DEBUGGER.with(|d| {
-                        let opt = d.borrow();
-                        opt.as_ref()
-                            .map(|rc| rc.borrow_mut().on_debugger_statement(stmt_offset))
-                    }) {
-                        return Err(pause_err);
-                    }
-                    // No debugger attached: debugger; is a no-op.
-                }
-
-                // ── TypeOf ──────────────────────────────────────────────────
-                //
-                // TypeOf [slot]:
-                //   Replace the accumulator with the string result of
-                //   `typeof acc`, following the ECMAScript specification
-                //   (notably, `typeof null === "object"`).
-                Opcode::TypeOf => {
-                    let type_str = match &frame.accumulator {
-                        JsValue::Undefined => "undefined",
-                        JsValue::Null => "object",
-                        JsValue::Boolean(_) => "boolean",
-                        JsValue::Smi(_) | JsValue::HeapNumber(_) => "number",
-                        JsValue::String(_) => "string",
-                        JsValue::Symbol(_) => "symbol",
-                        JsValue::BigInt(_) => "bigint",
-                        JsValue::Function(_) | JsValue::NativeFunction(_) => "function",
-                        JsValue::Object(_)
-                        | JsValue::Array(_)
-                        | JsValue::PlainObject(_)
-                        | JsValue::Error(_) => "object",
-                        JsValue::Generator(_) => "object",
-                        JsValue::Iterator(_) => "object",
-                        JsValue::Promise(_) => "object",
-                        JsValue::Context(_) => "object",
-                    };
-                    frame.accumulator = JsValue::String(type_str.to_owned());
-                }
-
-                // ── TestTypeOf ─────────────────────────────────────────────
-                //
-                // TestTypeOf [flag]:
-                //   Tests whether `typeof acc` matches the type encoded in
-                //   `flag`.  Sets the accumulator to a boolean result.
-                //   Flag encoding (V8 convention):
-                //     0 = number, 1 = string, 2 = symbol, 3 = boolean,
-                //     4 = bigint, 5 = undefined, 6 = function, 7 = object
-                Opcode::TestTypeOf => {
-                    let Operand::Flag(flag) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestTypeOf", 0));
-                    };
-                    let matches_type = match flag {
-                        0 => matches!(frame.accumulator, JsValue::Smi(_) | JsValue::HeapNumber(_)),
-                        1 => matches!(frame.accumulator, JsValue::String(_)),
-                        2 => matches!(frame.accumulator, JsValue::Symbol(_)),
-                        3 => matches!(frame.accumulator, JsValue::Boolean(_)),
-                        4 => matches!(frame.accumulator, JsValue::BigInt(_)),
-                        5 => matches!(frame.accumulator, JsValue::Undefined),
-                        6 => matches!(
-                            frame.accumulator,
-                            JsValue::Function(_) | JsValue::NativeFunction(_)
-                        ),
-                        7 => matches!(
-                            frame.accumulator,
-                            JsValue::Null
-                                | JsValue::Object(_)
-                                | JsValue::Array(_)
-                                | JsValue::PlainObject(_)
-                                | JsValue::Error(_)
-                                | JsValue::Generator(_)
-                                | JsValue::Iterator(_)
-                                | JsValue::Promise(_)
-                        ),
-                        _ => false,
-                    };
-                    frame.accumulator = JsValue::Boolean(matches_type);
-                }
-
-                // ── Type coercion ──────────────────────────────────────────
-                Opcode::ToNumber => {
-                    // operands[0] is a FeedbackSlot, ignored at runtime.
-                    let n = frame.accumulator.to_number()?;
-                    frame.accumulator = number_to_jsvalue(n);
-                }
-                Opcode::ToString => {
-                    let s = frame.accumulator.to_js_string()?;
-                    frame.accumulator = JsValue::String(s);
-                }
-                Opcode::ToBoolean => {
-                    // operands[0] is a FeedbackSlot, ignored at runtime.
-                    let b = frame.accumulator.to_boolean();
-                    frame.accumulator = JsValue::Boolean(b);
-                }
-                Opcode::ToObject => {
-                    // operands[0] is a Register destination.
-                    let Operand::Register(dst) = instr.operands[0] else {
-                        return Err(err_bad_operand("ToObject", 0));
-                    };
-                    match &frame.accumulator {
-                        JsValue::Null | JsValue::Undefined => {
-                            return Err(StatorError::TypeError(
-                                "Cannot convert undefined or null to object".to_string(),
-                            ));
-                        }
-                        _ => {
-                            // Objects/arrays stay as-is; primitives would need
-                            // wrapper objects (not yet implemented).
-                            let val = frame.accumulator.clone();
-                            frame.write_reg(dst, val)?;
-                        }
-                    }
-                }
-                Opcode::ToName => {
-                    // operands[0] is a Register destination.
-                    // Convert accumulator to a property key (string or symbol).
-                    let Operand::Register(dst) = instr.operands[0] else {
-                        return Err(err_bad_operand("ToName", 0));
-                    };
-                    let key = match &frame.accumulator {
-                        JsValue::String(_) | JsValue::Symbol(_) => frame.accumulator.clone(),
-                        other => JsValue::String(other.to_js_string()?),
-                    };
-                    frame.write_reg(dst, key)?;
-                }
-
-                // ── Unary arithmetic ──────────────────────────────────────────
-                Opcode::Negate => {
-                    // operands[0] is a FeedbackSlot, ignored at runtime.
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(n.wrapping_neg());
-                    } else {
-                        let n = frame.accumulator.to_number()?;
-                        frame.accumulator = number_to_jsvalue(-n);
-                    }
-                }
-                Opcode::BitwiseNot => {
-                    // operands[0] is a FeedbackSlot, ignored at runtime.
-                    if let JsValue::BigInt(n) = &frame.accumulator {
-                        frame.accumulator = JsValue::BigInt(!n);
-                    } else {
-                        let n = frame.accumulator.to_number()? as i32;
-                        frame.accumulator = JsValue::Smi(!n);
-                    }
-                }
-
-                // CreateEmptyObjectLiteral:
-                //   Create a new empty PlainObject and store it in the accumulator.
-                Opcode::CreateEmptyObjectLiteral => {
-                    frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
-                }
-
-                // CreateEmptyArrayLiteral [feedback_slot]:
-                //   Create a new empty array-like PlainObject and store it in
-                //   the accumulator.  The bytecode generator populates the
-                //   elements afterwards via StaInArrayLiteral.
-                Opcode::CreateEmptyArrayLiteral => {
-                    // operands[0] is a FeedbackSlot, ignored at runtime.
-                    let mut map = HashMap::new();
-                    map.insert("length".to_string(), JsValue::Smi(0));
-                    frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
-                }
-
-                // CreateArrayLiteral [elements_const_pool_idx, feedback_slot, flags]:
-                //   Create an array from a constant-pool boilerplate.  For now
-                //   this simply creates an empty array-like PlainObject (the
-                //   bytecode generator currently uses CreateEmptyArrayLiteral
-                //   + StaInArrayLiteral instead).
-                Opcode::CreateArrayLiteral => {
-                    // operands: [ConstantPoolIdx, FeedbackSlot, Flag]
-                    let mut map = HashMap::new();
-                    map.insert("length".to_string(), JsValue::Smi(0));
-                    frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
-                }
-
-                // CreateArrayFromIterable:
-                //   Create an array from an iterable (used for spread to
-                //   array).  Consumes the iterator in the accumulator and
-                //   collects all yielded values into a new array.
-                Opcode::CreateArrayFromIterable => {
-                    let iterable = frame.accumulator.clone();
-                    let items: Vec<JsValue> = match &iterable {
-                        JsValue::Array(arr) => (**arr).clone(),
-                        JsValue::Iterator(iter) => {
-                            let mut out = Vec::new();
-                            loop {
-                                let mut it = iter.borrow_mut();
-                                match it.next_item() {
-                                    Some(v) => out.push(v),
-                                    None => break,
-                                }
-                            }
-                            out
-                        }
-                        _ => vec![],
-                    };
-                    let mut map = HashMap::new();
-                    for (i, v) in items.iter().enumerate() {
-                        map.insert(i.to_string(), v.clone());
-                    }
-                    map.insert("length".to_string(), JsValue::Smi(items.len() as i32));
-                    frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
-                }
-
-                // CreateObjectLiteral [boilerplate_const_pool_idx, feedback_slot, flags]:
-                //   Create an object from a constant-pool boilerplate.  For now
-                //   this simply creates an empty PlainObject (the bytecode
-                //   generator currently uses CreateEmptyObjectLiteral +
-                //   DefineNamedOwnProperty instead).
-                Opcode::CreateObjectLiteral => {
-                    // operands: [ConstantPoolIdx, FeedbackSlot, Flag]
-                    frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
-                }
-
-                // CreateRegExpLiteral [pattern_const_pool_idx, feedback_slot, flags]:
-                //   Create a RegExp object from the pattern string in the
-                //   constant pool.  Represented as a PlainObject with `source`
-                //   and `flags` properties so that JS code can inspect them.
-                Opcode::CreateRegExpLiteral => {
-                    let Operand::ConstantPoolIdx(pattern_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("CreateRegExpLiteral", 0));
-                    };
-                    // operands[1] = FeedbackSlot (ignored)
-                    let Operand::Flag(flags_val) = instr.operands[2] else {
-                        return Err(err_bad_operand("CreateRegExpLiteral", 2));
-                    };
-                    let pattern = match frame.bytecode_array.get_constant(pattern_idx) {
-                        Some(ConstantPoolEntry::String(s)) => decode_string_constant(s),
-                        _ => String::new(),
-                    };
-                    // Decode flag bits back to a flag string.
-                    let mut flags_str = String::new();
-                    if flags_val & 0x01 != 0 {
-                        flags_str.push('g');
-                    }
-                    if flags_val & 0x02 != 0 {
-                        flags_str.push('i');
-                    }
-                    if flags_val & 0x04 != 0 {
-                        flags_str.push('m');
-                    }
-                    if flags_val & 0x08 != 0 {
-                        flags_str.push('s');
-                    }
-                    if flags_val & 0x10 != 0 {
-                        flags_str.push('u');
-                    }
-                    if flags_val & 0x20 != 0 {
-                        flags_str.push('y');
-                    }
-                    let mut map = HashMap::new();
-                    map.insert("source".to_string(), JsValue::String(pattern.clone()));
-                    map.insert("flags".to_string(), JsValue::String(flags_str.clone()));
-                    // toString() representation: /pattern/flags
-                    map.insert(
-                        "toString".to_string(),
-                        JsValue::String(format!("/{pattern}/{flags_str}")),
-                    );
-                    frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
-                }
-
-                // StaInArrayLiteral [array_reg, index_reg, feedback_slot]:
-                //   Store the accumulator into the array at the given index.
-                //   The array is a PlainObject with string-keyed numeric
-                //   indices and a `"length"` property.
-                Opcode::StaInArrayLiteral => {
-                    let Operand::Register(arr_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("StaInArrayLiteral", 0));
-                    };
-                    let Operand::Register(idx_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("StaInArrayLiteral", 1));
-                    };
-                    // operands[2] is a FeedbackSlot, ignored at runtime.
-                    let arr = frame.read_reg(arr_v)?.clone();
-                    let key = frame.read_reg(idx_v)?.clone();
-                    let val = frame.accumulator.clone();
-                    if let JsValue::PlainObject(ref map) = arr {
-                        let idx_str = to_property_key(&key)?;
-                        map.borrow_mut().insert(idx_str, val);
-                        // Update length: max(current_length, index + 1).
-                        if let Some(idx) = to_array_index(&key) {
-                            let new_len = (idx + 1) as i32;
-                            let cur_len = match map.borrow().get("length") {
-                                Some(JsValue::Smi(n)) => *n,
-                                _ => 0,
-                            };
-                            if new_len > cur_len {
-                                map.borrow_mut()
-                                    .insert("length".to_string(), JsValue::Smi(new_len));
-                            }
-                        }
-                    }
-                    // Accumulator stays unchanged.
-                }
-
-                // DefineNamedOwnProperty [object_reg, name_const_pool_idx, feedback_slot]:
-                //   Define a named own property on the object held in
-                //   `object_reg`.  Semantically identical to StaNamedProperty
-                //   for PlainObjects.
-                Opcode::DefineNamedOwnProperty => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("DefineNamedOwnProperty", 0));
-                    };
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[1] else {
-                        return Err(err_bad_operand("DefineNamedOwnProperty", 1));
-                    };
-                    // operands[2] is a FeedbackSlot, ignored at runtime.
-                    let prop_name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "DefineNamedOwnProperty: property name is not a string".into(),
-                            ));
-                        }
-                    };
-                    let val = frame.accumulator.clone();
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    if let JsValue::PlainObject(ref map) = obj {
-                        map.borrow_mut().insert(prop_name, val);
-                    }
-                    // Accumulator stays unchanged.
-                }
-
-                // DefineKeyedOwnProperty [object_reg, key_reg, flags, feedback_slot]:
-                //   Define a keyed own property on the object held in
-                //   `object_reg`.  The key is in `key_reg`.  Semantically
-                //   identical to StaKeyedProperty for PlainObjects.
-                Opcode::DefineKeyedOwnProperty => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("DefineKeyedOwnProperty", 0));
-                    };
-                    let Operand::Register(key_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("DefineKeyedOwnProperty", 1));
-                    };
-                    // operands[2] = Flag (ignored), operands[3] = FeedbackSlot (ignored).
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    let key = frame.read_reg(key_v)?.clone();
-                    let val = frame.accumulator.clone();
-                    if let JsValue::PlainObject(ref map) = obj {
-                        let prop_name = to_property_key(&key)?;
-                        map.borrow_mut().insert(prop_name, val);
-                    }
-                    // Accumulator stays unchanged.
-                }
-
-                // DefineKeyedOwnPropertyInLiteral [object_reg, key_reg, flags, feedback_slot]:
-                //   Same as DefineKeyedOwnProperty — used in object literal
-                //   context.
-                Opcode::DefineKeyedOwnPropertyInLiteral => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("DefineKeyedOwnPropertyInLiteral", 0));
-                    };
-                    let Operand::Register(key_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("DefineKeyedOwnPropertyInLiteral", 1));
-                    };
-                    // operands[2] = Flag (ignored), operands[3] = FeedbackSlot (ignored).
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    let key = frame.read_reg(key_v)?.clone();
-                    let val = frame.accumulator.clone();
-                    if let JsValue::PlainObject(ref map) = obj {
-                        let prop_name = to_property_key(&key)?;
-                        map.borrow_mut().insert(prop_name, val);
-                    }
-                    // Accumulator stays unchanged.
-                }
-
-                // ── TestInstanceOf ──────────────────────────────────────────
-                //
-                // TestInstanceOf [constructor_reg, feedback_slot]:
-                //   Tests whether `acc` is an instance of the constructor held
-                //   in `constructor_reg`.  Sets the accumulator to a boolean.
-                //   Simplified: always `false` unless we can walk the prototype
-                //   chain (PlainObject with a `__proto__` key that matches the
-                //   constructor's `"prototype"` property).
-                Opcode::TestInstanceOf => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestInstanceOf", 0));
-                    };
-                    let constructor = frame.read_reg(v)?.clone();
-
-                    // Obtain the constructor's "prototype" property.
-                    let ctor_proto = match &constructor {
-                        JsValue::PlainObject(map) => map.borrow().get("prototype").cloned(),
-                        _ => None,
-                    };
-
-                    let result = if let Some(proto_val) = ctor_proto {
-                        // Walk the __proto__ chain of the accumulator object.
-                        let mut current = frame.accumulator.clone();
-                        let mut found = false;
-                        for _ in 0..256 {
-                            // Check if current is the same object as proto_val
-                            match &current {
-                                JsValue::PlainObject(map) => {
-                                    // If this object *is* the prototype, match.
-                                    if let JsValue::PlainObject(p) = &proto_val
-                                        && Rc::ptr_eq(map, p)
-                                    {
-                                        found = true;
-                                        break;
-                                    }
-                                    // Walk up via __proto__
-                                    let next = map.borrow().get("__proto__").cloned();
-                                    match next {
-                                        Some(v) => current = v,
-                                        None => break,
-                                    }
-                                }
-                                _ => break,
-                            }
-                        }
-                        found
-                    } else {
-                        false
-                    };
-
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-
-                // ── TestIn ─────────────────────────────────────────────────
-                //
-                // TestIn [object_reg, feedback_slot]:
-                //   Tests whether the property key held in the accumulator
-                //   exists in the object held in `object_reg`.  Sets the
-                //   accumulator to a boolean result.
-                Opcode::TestIn => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestIn", 0));
-                    };
-                    let object = frame.read_reg(v)?.clone();
-                    let key = &frame.accumulator;
-
-                    let result = match &object {
-                        JsValue::PlainObject(_) => {
-                            let prop = to_property_key(key)?;
-                            // Walk the prototype chain for `in` operator.
-                            !matches!(proto_lookup(&object, &prop), JsValue::Undefined)
-                        }
-                        JsValue::Array(items) => {
-                            // "length" is always present on arrays.
-                            if let JsValue::String(s) = key
-                                && s == "length"
-                            {
-                                true
-                            } else if let Some(idx) = to_array_index(key) {
-                                idx < items.len()
-                            } else {
-                                false
-                            }
-                        }
-                        _ => false,
-                    };
-
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-
-                // ── For-in ─────────────────────────────────────────────────
-                //
-                // ForInEnumerate [obj_reg]:
-                //   Collect the enumerable string-keyed own properties of the
-                //   object stored in `obj_reg` into a JsValue::Array and set
-                //   the accumulator to that array.  If the value is null or
-                //   undefined the result is an empty array.
-                Opcode::ForInEnumerate => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("ForInEnumerate", 0));
-                    };
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    let keys: Vec<JsValue> = match &obj {
-                        JsValue::PlainObject(map) => map
-                            .borrow()
-                            .keys()
-                            .map(|k| JsValue::String(k.clone()))
-                            .collect(),
-                        JsValue::Array(items) => {
-                            let mut ks: Vec<JsValue> = (0..items.len())
-                                .map(|i| JsValue::String(i.to_string()))
-                                .collect();
-                            ks.push(JsValue::String("length".to_string()));
-                            ks
-                        }
-                        JsValue::Null | JsValue::Undefined => vec![],
-                        _ => vec![],
-                    };
-                    frame.accumulator = JsValue::Array(Rc::new(keys));
-                }
-
-                // ForInPrepare [cache_array_reg, feedback_slot]:
-                //   Read the length of the key array stored in
-                //   `cache_array_reg` and set the accumulator to that length
-                //   as an Smi.
-                Opcode::ForInPrepare => {
-                    let Operand::Register(keys_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("ForInPrepare", 0));
-                    };
-                    // operands[1] is a FeedbackSlot, ignored at runtime.
-                    let keys = frame.read_reg(keys_v)?.clone();
-                    let len = match &keys {
-                        JsValue::Array(items) => items.len() as i32,
-                        _ => 0,
-                    };
-                    frame.accumulator = JsValue::Smi(len);
-                }
-
-                // ForInNext [receiver_reg, index_reg, cache_array_reg,
-                //            feedback_slot]:
-                //   Read the key at position `index` from the enumeration
-                //   cache array and set the accumulator to that key.
-                Opcode::ForInNext => {
-                    let Operand::Register(_receiver_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("ForInNext", 0));
-                    };
-                    let Operand::Register(idx_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("ForInNext", 1));
-                    };
-                    let Operand::Register(keys_v) = instr.operands[2] else {
-                        return Err(err_bad_operand("ForInNext", 2));
-                    };
-                    // operands[3] is a FeedbackSlot, ignored at runtime.
-                    let idx = match frame.read_reg(idx_v)? {
-                        JsValue::Smi(n) => *n as usize,
-                        _ => 0,
-                    };
-                    let keys = frame.read_reg(keys_v)?.clone();
-                    let key = match &keys {
-                        JsValue::Array(items) => {
-                            items.get(idx).cloned().unwrap_or(JsValue::Undefined)
-                        }
-                        _ => JsValue::Undefined,
-                    };
-                    frame.accumulator = key;
-                }
-
-                // ForInStep [index_reg]:
-                //   Read the current index from `index_reg`, increment by 1,
-                //   and set the accumulator to the new value.
-                Opcode::ForInStep => {
-                    let Operand::Register(idx_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("ForInStep", 0));
-                    };
-                    let idx = match frame.read_reg(idx_v)? {
-                        JsValue::Smi(n) => *n,
-                        _ => 0,
-                    };
-                    frame.accumulator = JsValue::Smi(idx + 1);
-                }
-
-                // JumpIfForInDone [offset, index_reg, cache_length_reg]:
-                //   Compare the index in `index_reg` to the length in
-                //   `cache_length_reg`.  If index >= length, jump by offset.
-                Opcode::JumpIfForInDone => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfForInDone", 0));
-                    };
-                    let Operand::Register(idx_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("JumpIfForInDone", 1));
-                    };
-                    let Operand::Register(len_v) = instr.operands[2] else {
-                        return Err(err_bad_operand("JumpIfForInDone", 2));
-                    };
-                    let idx = match frame.read_reg(idx_v)? {
-                        JsValue::Smi(n) => *n,
-                        _ => 0,
-                    };
-                    let len = match frame.read_reg(len_v)? {
-                        JsValue::Smi(n) => *n,
-                        _ => 0,
-                    };
-                    if idx >= len {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-
-                // ── Delete property ───────────────────────────────────────
-
-                // DeletePropertySloppy [object_reg]:
-                //   Delete the property named by the accumulator from the
-                //   object in `object_reg`.  Non-configurable properties
-                //   silently fail; the accumulator receives `true`/`false`.
-                Opcode::DeletePropertySloppy => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("DeletePropertySloppy", 0));
-                    };
-                    let key = to_property_key(&frame.accumulator)?;
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    let removed = if let JsValue::PlainObject(ref map) = obj {
-                        map.borrow_mut().remove(&key).is_some()
-                    } else {
-                        false
-                    };
-                    frame.accumulator = JsValue::Boolean(removed);
-                }
-
-                // DeletePropertyStrict [object_reg]:
-                //   Like DeletePropertySloppy but throws TypeError when the
-                //   property exists and is non-configurable.  For our
-                //   simplified PlainObject model every property is
-                //   configurable, so this behaves the same as sloppy mode.
-                Opcode::DeletePropertyStrict => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("DeletePropertyStrict", 0));
-                    };
-                    let key = to_property_key(&frame.accumulator)?;
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    if let JsValue::PlainObject(ref map) = obj {
-                        map.borrow_mut().remove(&key);
-                    }
-                    frame.accumulator = JsValue::Boolean(true);
-                }
-
-                // ── Arguments / rest parameter ───────────────────────────────
-
-                // CreateRestParameter []:
-                //   Collect all arguments beyond the formal parameter count
-                //   into a JsValue::Array.
-                Opcode::CreateRestParameter => {
-                    let param_count = frame.bytecode_array.parameter_count() as usize;
-                    let rest: Vec<JsValue> = if frame.registers.len() > param_count {
-                        frame.registers[param_count..].to_vec()
-                    } else {
-                        vec![]
-                    };
-                    frame.accumulator = JsValue::Array(Rc::new(rest));
-                }
-
-                // CreateMappedArguments []:
-                //   Create a sloppy-mode `arguments` object.  Implemented as
-                //   a PlainObject with indexed string keys and a `length`
-                //   property.
-                Opcode::CreateMappedArguments => {
-                    let param_count = frame.bytecode_array.parameter_count() as usize;
-                    let args: Vec<JsValue> =
-                        frame.registers.get(..param_count).unwrap_or(&[]).to_vec();
-                    let map: HashMap<String, JsValue> = args
-                        .iter()
-                        .enumerate()
-                        .map(|(i, v)| (i.to_string(), v.clone()))
-                        .chain(std::iter::once((
-                            "length".to_string(),
-                            JsValue::Smi(args.len() as i32),
-                        )))
-                        .collect();
-                    frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
-                }
-
-                // CreateUnmappedArguments []:
-                //   Create a strict-mode `arguments` object (snapshot copy).
-                //   Same shape as mapped but values are not aliased.
-                Opcode::CreateUnmappedArguments => {
-                    let param_count = frame.bytecode_array.parameter_count() as usize;
-                    let args: Vec<JsValue> =
-                        frame.registers.get(..param_count).unwrap_or(&[]).to_vec();
-                    let map: HashMap<String, JsValue> = args
-                        .iter()
-                        .enumerate()
-                        .map(|(i, v)| (i.to_string(), v.clone()))
-                        .chain(std::iter::once((
-                            "length".to_string(),
-                            JsValue::Smi(args.len() as i32),
-                        )))
-                        .collect();
-                    frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
-                }
-
-                // ── Throw-if-hole opcodes (TDZ checks) ──────────────────────
-
-                // ThrowReferenceErrorIfHole [name_idx]:
-                //   If the accumulator is Undefined (representing a TDZ hole),
-                //   throw a ReferenceError with the variable name from the
-                //   constant pool.
-                Opcode::ThrowReferenceErrorIfHole => {
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("ThrowReferenceErrorIfHole", 0));
-                    };
-                    if frame.accumulator == JsValue::Undefined {
-                        let name = match frame.bytecode_array.get_constant(name_idx) {
-                            Some(ConstantPoolEntry::String(s)) => s.clone(),
-                            _ => "<unknown>".to_string(),
-                        };
-                        return Err(StatorError::ReferenceError(format!(
-                            "Cannot access '{name}' before initialization"
-                        )));
-                    }
-                }
-
-                // ThrowSuperNotCalledIfHole []:
-                //   If the accumulator is Undefined (hole), throw
-                //   ReferenceError because super() was never called.
-                Opcode::ThrowSuperNotCalledIfHole => {
-                    if frame.accumulator == JsValue::Undefined {
-                        return Err(StatorError::ReferenceError(
-                            "Must call super constructor in derived class \
-                             before accessing 'this' or returning from \
-                             derived constructor"
-                                .to_string(),
-                        ));
-                    }
-                }
-
-                // ThrowSuperAlreadyCalledIfNotHole []:
-                //   If the accumulator is NOT Undefined (not a hole), throw
-                //   ReferenceError because super() was already called.
-                Opcode::ThrowSuperAlreadyCalledIfNotHole => {
-                    if frame.accumulator != JsValue::Undefined {
-                        return Err(StatorError::ReferenceError(
-                            "Super constructor may only be called once".to_string(),
-                        ));
-                    }
-                }
-
-                // ── CallProperty variants ────────────────────────────────────
-
-                // CallProperty0 [callee_reg, receiver_reg, feedback]:
-                //   Call `callee` with `receiver` as `this` and zero
-                //   arguments.
-                Opcode::CallProperty0 => {
-                    let Operand::Register(callee_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallProperty0", 0));
-                    };
-                    let callee = frame.read_reg(callee_v)?.clone();
-                    dispatch_call(frame, &callee, vec![])?;
-                }
-
-                // CallProperty1 [callee_reg, receiver_reg, arg0_reg, feedback]:
-                //   Call `callee` with `receiver` as `this` and one argument.
-                Opcode::CallProperty1 => {
-                    let Operand::Register(callee_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallProperty1", 0));
-                    };
-                    let Operand::Register(arg0_v) = instr.operands[2] else {
-                        return Err(err_bad_operand("CallProperty1", 2));
-                    };
-                    let callee = frame.read_reg(callee_v)?.clone();
-                    let arg0 = frame.read_reg(arg0_v)?.clone();
-                    dispatch_call(frame, &callee, vec![arg0])?;
-                }
-
-                // CallProperty2 [callee_reg, receiver_reg, arg0, arg1,
-                //                 feedback]:
-                //   Call `callee` with `receiver` as `this` and two arguments.
-                Opcode::CallProperty2 => {
-                    let Operand::Register(callee_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallProperty2", 0));
-                    };
-                    let Operand::Register(arg0_v) = instr.operands[2] else {
-                        return Err(err_bad_operand("CallProperty2", 2));
-                    };
-                    let Operand::Register(arg1_v) = instr.operands[3] else {
-                        return Err(err_bad_operand("CallProperty2", 3));
-                    };
-                    let callee = frame.read_reg(callee_v)?.clone();
-                    let arg0 = frame.read_reg(arg0_v)?.clone();
-                    let arg1 = frame.read_reg(arg1_v)?.clone();
-                    dispatch_call(frame, &callee, vec![arg0, arg1])?;
-                }
-
-                // ── CallRuntime ──────────────────────────────────────────────
-
-                // CallRuntime [runtime_id, args_start, arg_count]:
-                //   Dispatch to an internal runtime function.  Most runtime
-                //   functions are optimisation hints that are not
-                //   correctness-critical, so unrecognised IDs are no-ops.
-                Opcode::CallRuntime => {
-                    let Operand::RuntimeId(runtime_id) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallRuntime", 0));
-                    };
-                    let Operand::Register(args_start_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("CallRuntime", 1));
-                    };
-                    let Operand::RegisterCount(arg_count) = instr.operands[2] else {
-                        return Err(err_bad_operand("CallRuntime", 2));
-                    };
-
-                    if runtime_id == crate::bytecode::bytecode_generator::RUNTIME_DYNAMIC_IMPORT {
-                        use crate::builtins::promise::{MicrotaskQueue, promise_resolve};
-
-                        let args = collect_args(frame, args_start_v, arg_count)?;
-                        let specifier = args.first().cloned().unwrap_or(JsValue::Undefined);
-
-                        // Build a namespace object with a default export
-                        // equal to the specifier string (stub for now — a
-                        // full implementation would resolve a module).
-                        let ns = HashMap::new();
-                        let ns_val = JsValue::PlainObject(Rc::new(RefCell::new(ns)));
-
-                        let queue = MicrotaskQueue::new();
-                        let p = promise_resolve(ns_val, &queue);
-                        queue.drain();
-                        frame.accumulator = JsValue::Promise(p);
-
-                        let _ = specifier; // consumed for future use
-                    }
-                    // Unrecognised runtime IDs are no-ops.
-                }
-
-                // ── Named own property / lookup slot ─────────────────────────
-
-                // StaNamedOwnProperty [object_reg, name_idx, feedback]:
-                //   Define an own property on `object_reg` (like
-                //   Object.defineProperty).  For the current PlainObject
-                //   model this is identical to StaNamedProperty.
-                Opcode::StaNamedOwnProperty => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("StaNamedOwnProperty", 0));
-                    };
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[1] else {
-                        return Err(err_bad_operand("StaNamedOwnProperty", 1));
-                    };
-                    let prop_name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "StaNamedOwnProperty: property name is \
-                                     not a string"
-                                    .into(),
-                            ));
-                        }
-                    };
-                    let val = frame.accumulator.clone();
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    if let JsValue::PlainObject(ref map) = obj {
-                        map.borrow_mut().insert(prop_name, val);
-                    }
-                }
-
-                // StaLookupSlot [name_idx, flags]:
-                //   Store the accumulator to a named variable by walking the
-                //   scope chain.  Simplified: stores directly into
-                //   `global_env`.
-                Opcode::StaLookupSlot => {
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("StaLookupSlot", 0));
-                    };
-                    let name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "StaLookupSlot: slot name is not a string".into(),
-                            ));
-                        }
-                    };
-                    let val = frame.accumulator.clone();
-                    frame.global_env.borrow_mut().insert(name, val);
-                }
-
-                // LdaLookupSlot [name_idx]:
-                //   Dynamic lookup of a variable name in the scope chain.
-                //   Simplified: looks up in `global_env`, throws
-                //   ReferenceError if not found.
-                Opcode::LdaLookupSlot => {
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaLookupSlot", 0));
-                    };
-                    let name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "LdaLookupSlot: slot name is not a string".into(),
-                            ));
-                        }
-                    };
-                    frame.accumulator = match frame.global_env.borrow().get(&name) {
-                        Some(v) => v.clone(),
-                        None => {
-                            return Err(StatorError::ReferenceError(format!(
-                                "{name} is not defined"
-                            )));
-                        }
-                    };
-                }
-
-                // LdaLookupSlotInsideTypeof [name_idx]:
-                //   Same as LdaLookupSlot but returns undefined instead of
-                //   throwing ReferenceError (used inside `typeof`).
-                Opcode::LdaLookupSlotInsideTypeof => {
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaLookupSlotInsideTypeof", 0));
-                    };
-                    let name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "LdaLookupSlotInsideTypeof: slot name is not a string".into(),
-                            ));
-                        }
-                    };
-                    frame.accumulator = frame
-                        .global_env
-                        .borrow()
-                        .get(&name)
-                        .cloned()
-                        .unwrap_or(JsValue::Undefined);
-                }
-
-                // LdaLookupContextSlot [name_idx, slot_idx, depth]:
-                //   Dynamic lookup resolving to a context slot.
-                //   Simplified: falls back to `global_env`.
-                Opcode::LdaLookupContextSlot => {
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaLookupContextSlot", 0));
-                    };
-                    let name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "LdaLookupContextSlot: slot name is not a string".into(),
-                            ));
-                        }
-                    };
-                    frame.accumulator = match frame.global_env.borrow().get(&name) {
-                        Some(v) => v.clone(),
-                        None => {
-                            return Err(StatorError::ReferenceError(format!(
-                                "{name} is not defined"
-                            )));
-                        }
-                    };
-                }
-
-                // LdaLookupContextSlotInsideTypeof [name_idx, slot_idx, depth]:
-                //   Same as LdaLookupContextSlot but returns undefined instead
-                //   of throwing (used inside `typeof`).
-                Opcode::LdaLookupContextSlotInsideTypeof => {
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaLookupContextSlotInsideTypeof", 0));
-                    };
-                    let name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "LdaLookupContextSlotInsideTypeof: slot name is not a string"
-                                    .into(),
-                            ));
-                        }
-                    };
-                    frame.accumulator = frame
-                        .global_env
-                        .borrow()
-                        .get(&name)
-                        .cloned()
-                        .unwrap_or(JsValue::Undefined);
-                }
-
-                // LdaLookupGlobalSlot [name_idx, slot, depth]:
-                //   Dynamic lookup resolving to a global slot.
-                //   Simplified: looks up in `global_env`, throws
-                //   ReferenceError if not found.
-                Opcode::LdaLookupGlobalSlot => {
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaLookupGlobalSlot", 0));
-                    };
-                    let name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "LdaLookupGlobalSlot: slot name is not a string".into(),
-                            ));
-                        }
-                    };
-                    frame.accumulator = match frame.global_env.borrow().get(&name) {
-                        Some(v) => v.clone(),
-                        None => {
-                            return Err(StatorError::ReferenceError(format!(
-                                "{name} is not defined"
-                            )));
-                        }
-                    };
-                }
-
-                // LdaLookupGlobalSlotInsideTypeof [name_idx, slot, depth]:
-                //   Same as LdaLookupGlobalSlot but returns undefined instead
-                //   of throwing (used inside `typeof`).
-                Opcode::LdaLookupGlobalSlotInsideTypeof => {
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaLookupGlobalSlotInsideTypeof", 0));
-                    };
-                    let name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "LdaLookupGlobalSlotInsideTypeof: slot name is not a string".into(),
-                            ));
-                        }
-                    };
-                    frame.accumulator = frame
-                        .global_env
-                        .borrow()
-                        .get(&name)
-                        .cloned()
-                        .unwrap_or(JsValue::Undefined);
-                }
-
-                // LdaNamedPropertyFromSuper [obj_reg, name_idx, feedback_slot]:
-                //   Load a named property from the super object.  The
-                //   accumulator holds the home object; `obj_reg` holds the
-                //   receiver.  Simplified: delegates to `proto_lookup` on the
-                //   receiver.
-                Opcode::LdaNamedPropertyFromSuper => {
-                    let Operand::Register(obj_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("LdaNamedPropertyFromSuper", 0));
-                    };
-                    let Operand::ConstantPoolIdx(name_idx) = instr.operands[1] else {
-                        return Err(err_bad_operand("LdaNamedPropertyFromSuper", 1));
-                    };
-                    let prop_name = match frame.bytecode_array.get_constant(name_idx) {
-                        Some(ConstantPoolEntry::String(s)) => s.clone(),
-                        _ => {
-                            return Err(StatorError::Internal(
-                                "LdaNamedPropertyFromSuper: property name is not a string".into(),
-                            ));
-                        }
-                    };
-                    let obj = frame.read_reg(obj_v)?.clone();
-                    frame.accumulator = proto_lookup(&obj, &prop_name);
-                }
-
-                // GetTemplateObject [template_idx, feedback_slot]:
-                //   Create an array of template strings, freeze it, and cache
-                //   by the current bytecode offset.
-                Opcode::GetTemplateObject => {
-                    let Operand::ConstantPoolIdx(tpl_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("GetTemplateObject", 0));
-                    };
-                    let cache_key = byte_offsets[frame.pc - 1] as u32;
-                    if let Some(cached) = frame.template_cache.get(&cache_key) {
-                        frame.accumulator = cached.clone();
-                    } else {
-                        let entry =
-                            frame.bytecode_array.get_constant(tpl_idx).ok_or_else(|| {
-                                StatorError::Internal(format!(
-                                    "GetTemplateObject: constant pool index {tpl_idx} out of bounds"
-                                ))
-                            })?;
-                        let tpl_val = constant_to_value(entry);
-                        frame.template_cache.insert(cache_key, tpl_val.clone());
-                        frame.accumulator = tpl_val;
-                    }
-                }
-
-                // SetPendingMessage:
-                //   Swap the accumulator with the pending-exception message
-                //   slot.  Used by `finally` blocks to save/restore the
-                //   pending exception.
-                Opcode::SetPendingMessage => {
-                    std::mem::swap(&mut frame.accumulator, &mut frame.pending_message);
-                }
-
-                // TestReferenceEqual [reg]:
-                //   Strict reference identity check (===).
-                Opcode::TestReferenceEqual => {
-                    let Operand::Register(v) = instr.operands[0] else {
-                        return Err(err_bad_operand("TestReferenceEqual", 0));
-                    };
-                    let rhs = frame.read_reg(v)?.clone();
-                    let result = strict_eq(&frame.accumulator, &rhs);
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-
-                // TestUndetectable:
-                //   Check if the accumulator is null or undefined (the two
-                //   "undetectable" values in ECMAScript).
-                Opcode::TestUndetectable => {
-                    let result = matches!(frame.accumulator, JsValue::Null | JsValue::Undefined);
-                    frame.accumulator = JsValue::Boolean(result);
-                }
-
-                // JumpIfJSReceiver [offset]:
-                //   Jump if the accumulator is a JS receiver (object type, not
-                //   null, undefined, or a primitive).
-                Opcode::JumpIfJSReceiver => {
-                    let Operand::JumpOffset(delta) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfJSReceiver", 0));
-                    };
-                    if is_js_receiver(&frame.accumulator) {
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-
-                // JumpIfJSReceiverConstant [idx]:
-                //   Constant-pool variant of JumpIfJSReceiver.
-                Opcode::JumpIfJSReceiverConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfJSReceiverConstant", 0));
-                    };
-                    if is_js_receiver(&frame.accumulator) {
-                        let delta =
-                            constant_pool_jump_delta(frame, idx, "JumpIfJSReceiverConstant")?;
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-
-                // ToNumeric [feedback_slot]:
-                //   Abstract ToNumeric operation — converts the accumulator to
-                //   a numeric value (Number or BigInt).  BigInt values pass
-                //   through unchanged.
-                Opcode::ToNumeric => {
-                    // operands[0] is a FeedbackSlot, ignored at runtime.
-                    if !matches!(frame.accumulator, JsValue::BigInt(_)) {
-                        let n = frame.accumulator.to_number()?;
-                        frame.accumulator = number_to_jsvalue(n);
-                    }
-                }
-
-                // ── Wide / ExtraWide prefix opcodes ────────────────────────
-                //
-                // These are encoding prefixes consumed by the decoder; they
-                // never appear as `instr.opcode` in the pre-decoded stream.
-                Opcode::Wide | Opcode::ExtraWide => {
+        // Outer loop: re-entered when a TailCall opcode rewrites the frame
+        // with a new bytecode array (proper tail-call trampoline).
+        'tail_call: loop {
+            // Pre-decode the bytecode once and capture byte offsets for jump resolution.
+            let (instructions, byte_offsets) =
+                decode_with_byte_offsets(frame.bytecode_array.bytecodes())?;
+            // Clone the handler table once so the borrow on bytecode_array is released
+            // before we start mutating the frame.
+            let handler_table: Vec<HandlerTableEntry> =
+                frame.bytecode_array.handler_table().to_vec();
+
+            loop {
+                // ── CPU profiler checkpoint ────────────────────────────────────
+                crate::inspector::profiler::maybe_record_sample();
+
+                if frame.pc >= instructions.len() {
                     return Err(StatorError::Internal(
-                        "Wide/ExtraWide prefix should not appear as a decoded opcode".into(),
+                        "bytecode ended without a Return instruction".into(),
                     ));
                 }
 
-                // ── Constant-pool jump variants ───────────────────────────
+                // ── Debug hook (pre-fetch) ─────────────────────────────────────
                 //
-                // Each *Constant jump reads a constant-pool index whose
-                // Number entry is the byte-level jump offset, then applies
-                // the same condition as the non-constant counterpart.
+                // Check for breakpoints and step conditions *before* fetching the
+                // next instruction so that the paused frame state reflects what is
+                // *about* to execute (the program counter still points at the
+                // instruction that would fire next).
+                let current_offset = byte_offsets[frame.pc] as u32;
+                if let Some(pause_err) = ACTIVE_DEBUGGER.with(|d| {
+                    let opt = d.borrow();
+                    opt.as_ref()
+                        .and_then(|rc| rc.borrow_mut().check_pause_at(current_offset))
+                }) {
+                    return Err(pause_err);
+                }
 
-                // JumpConstant [idx]: unconditional jump via constant pool.
-                Opcode::JumpConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpConstant", 0));
-                    };
-                    let delta = constant_pool_jump_delta(frame, idx, "JumpConstant")?;
-                    frame.pc = resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                }
-                // JumpIfTrueConstant [idx]
-                Opcode::JumpIfTrueConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfTrueConstant", 0));
-                    };
-                    if matches!(frame.accumulator, JsValue::Boolean(true)) {
-                        let delta = constant_pool_jump_delta(frame, idx, "JumpIfTrueConstant")?;
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                // JumpIfFalseConstant [idx]
-                Opcode::JumpIfFalseConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfFalseConstant", 0));
-                    };
-                    if matches!(frame.accumulator, JsValue::Boolean(false)) {
-                        let delta = constant_pool_jump_delta(frame, idx, "JumpIfFalseConstant")?;
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                // JumpIfToBooleanTrueConstant [idx]
-                Opcode::JumpIfToBooleanTrueConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfToBooleanTrueConstant", 0));
-                    };
-                    if frame.accumulator.to_boolean() {
-                        let delta =
-                            constant_pool_jump_delta(frame, idx, "JumpIfToBooleanTrueConstant")?;
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                // JumpIfToBooleanFalseConstant [idx]
-                Opcode::JumpIfToBooleanFalseConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfToBooleanFalseConstant", 0));
-                    };
-                    if !frame.accumulator.to_boolean() {
-                        let delta =
-                            constant_pool_jump_delta(frame, idx, "JumpIfToBooleanFalseConstant")?;
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                // JumpIfNullConstant [idx]
-                Opcode::JumpIfNullConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfNullConstant", 0));
-                    };
-                    if frame.accumulator.is_null() {
-                        let delta = constant_pool_jump_delta(frame, idx, "JumpIfNullConstant")?;
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                // JumpIfNotNullConstant [idx]
-                Opcode::JumpIfNotNullConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfNotNullConstant", 0));
-                    };
-                    if !frame.accumulator.is_null() {
-                        let delta = constant_pool_jump_delta(frame, idx, "JumpIfNotNullConstant")?;
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                // JumpIfUndefinedConstant [idx]
-                Opcode::JumpIfUndefinedConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfUndefinedConstant", 0));
-                    };
-                    if frame.accumulator.is_undefined() {
-                        let delta =
-                            constant_pool_jump_delta(frame, idx, "JumpIfUndefinedConstant")?;
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                // JumpIfNotUndefinedConstant [idx]
-                Opcode::JumpIfNotUndefinedConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfNotUndefinedConstant", 0));
-                    };
-                    if !frame.accumulator.is_undefined() {
-                        let delta =
-                            constant_pool_jump_delta(frame, idx, "JumpIfNotUndefinedConstant")?;
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
-                    }
-                }
-                // JumpIfUndefinedOrNullConstant [idx]
-                Opcode::JumpIfUndefinedOrNullConstant => {
-                    let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("JumpIfUndefinedOrNullConstant", 0));
-                    };
-                    if frame.accumulator.is_nullish() {
-                        let delta =
-                            constant_pool_jump_delta(frame, idx, "JumpIfUndefinedOrNullConstant")?;
-                        frame.pc =
-                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                // ── Fetch ──────────────────────────────────────────────────────
+                let instr = &instructions[frame.pc];
+                frame.pc += 1;
+
+                // ── Instruction limit check ────────────────────────────────────
+                if frame.instruction_limit > 0 {
+                    frame.instructions_executed += 1;
+                    if frame.instructions_executed > frame.instruction_limit {
+                        return Err(StatorError::Internal("instruction limit exceeded".into()));
                     }
                 }
 
-                // ── Host integration calls ────────────────────────────────
-                //
-                // CallJSRuntime, InvokeIntrinsic, CallRuntimeForPair: these
-                // call into the host runtime.  Currently treated as no-ops
-                // (like CallRuntime) since the runtime functions they target
-                // are optimisation hints or non-critical for correctness.
-
-                // CallJSRuntime [context_idx, args_start, args_count]
-                Opcode::CallJSRuntime => {
-                    let Operand::ConstantPoolIdx(_ctx_idx) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallJSRuntime", 0));
-                    };
-                    // No-op: accumulator is left unchanged.
-                }
-                // InvokeIntrinsic [function_id, args_start, args_count]
-                Opcode::InvokeIntrinsic => {
-                    let Operand::RuntimeId(_runtime_id) = instr.operands[0] else {
-                        return Err(err_bad_operand("InvokeIntrinsic", 0));
-                    };
-                    // No-op: accumulator is left unchanged.
-                }
-                // CallRuntimeForPair [function_id, args_start, args_count, first_return]
-                Opcode::CallRuntimeForPair => {
-                    let Operand::RuntimeId(_runtime_id) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallRuntimeForPair", 0));
-                    };
-                    // No-op: accumulator is left unchanged.
-                }
-
-                // ── ConstructForwardAllArgs ────────────────────────────────
-                //
-                // ConstructForwardAllArgs [constructor, slot]:
-                //   Like Construct, but instead of reading args from an
-                //   explicit register range, forward all parameter registers
-                //   from the current frame to the callee.
-                Opcode::ConstructForwardAllArgs => {
-                    let Operand::Register(ctor_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("ConstructForwardAllArgs", 0));
-                    };
-                    // operands[1] is a FeedbackSlot, ignored at runtime.
-                    let ctor = frame.read_reg(ctor_v)?.clone();
-                    let ctor_proto = proto_lookup(&ctor, "prototype");
-                    let param_count = frame.bytecode_array.parameter_count() as usize;
-                    let args: Vec<JsValue> =
-                        frame.registers.get(..param_count).unwrap_or(&[]).to_vec();
-                    match ctor {
-                        JsValue::Function(ba) => {
-                            let mut callee_frame = InterpreterFrame::new_with_globals(
-                                (*ba).clone(),
-                                args,
-                                Rc::clone(&frame.global_env),
-                            );
-                            push_call_frame("<anonymous>")?;
-                            let result = Interpreter::run(&mut callee_frame);
-                            pop_call_frame();
-                            let val = result?;
-                            frame.accumulator = wire_construct_prototype(val, &ctor_proto);
-                        }
-                        JsValue::NativeFunction(f) => {
-                            frame.accumulator = f(args)?;
-                        }
-                        other => {
-                            return Err(StatorError::TypeError(format!(
-                                "ConstructForwardAllArgs: constructor is not a function (got {other:?})"
-                            )));
-                        }
+                // ── Decode + Dispatch ──────────────────────────────────────────
+                match instr.opcode {
+                    // ── Load immediates ────────────────────────────────────────
+                    Opcode::LdaZero => {
+                        frame.accumulator = JsValue::Smi(0);
                     }
-                }
-
-                // ── CollectTypeProfile ─────────────────────────────────────
-                //
-                // CollectTypeProfile [position]:
-                //   Records type-profile information for the accumulator.
-                //   This is a profiling-only instruction; a no-op for
-                //   correctness.
-                Opcode::CollectTypeProfile => {
-                    // No-op: operands[0] is an Immediate (position), ignored.
-                }
-
-                // ── CreateObjectFromIterable ──────────────────────────────
-                //
-                // CreateObjectFromIterable:
-                //   Creates an object by spreading an iterable (e.g.
-                //   `{...iterable}`).  Consumes the accumulator and creates a
-                //   new PlainObject from its key-value pairs.
-                Opcode::CreateObjectFromIterable => {
-                    let iterable = frame.accumulator.clone();
-                    let map: HashMap<String, JsValue> = match &iterable {
-                        JsValue::PlainObject(obj) => obj.borrow().clone(),
-                        JsValue::Array(arr) => {
-                            let mut m = HashMap::new();
-                            for (i, v) in arr.iter().enumerate() {
-                                m.insert(i.to_string(), v.clone());
-                            }
-                            m.insert("length".to_string(), JsValue::Smi(arr.len() as i32));
-                            m
-                        }
-                        JsValue::Iterator(iter) => {
-                            let mut m = HashMap::new();
-                            let mut idx = 0usize;
-                            loop {
-                                let mut it = iter.borrow_mut();
-                                match it.next_item() {
-                                    Some(v) => {
-                                        m.insert(idx.to_string(), v);
-                                        idx += 1;
-                                    }
-                                    None => break,
-                                }
-                            }
-                            m.insert("length".to_string(), JsValue::Smi(idx as i32));
-                            m
-                        }
-                        _ => HashMap::new(),
-                    };
-                    frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
-                }
-
-                // ── CallDirectEval ────────────────────────────────────────
-                // Emitted when the callee is the bare identifier `eval`.
-                // At runtime: if the callee is still the built-in eval
-                // function, execute the source sharing the caller's
-                // `global_env` (direct eval); otherwise fall through to a
-                // normal function call.
-                Opcode::CallDirectEval => {
-                    let Operand::Register(callee_v) = instr.operands[0] else {
-                        return Err(err_bad_operand("CallDirectEval", 0));
-                    };
-                    let Operand::Register(args_start_v) = instr.operands[1] else {
-                        return Err(err_bad_operand("CallDirectEval", 1));
-                    };
-                    let Operand::RegisterCount(arg_count) = instr.operands[2] else {
-                        return Err(err_bad_operand("CallDirectEval", 2));
-                    };
-                    let callee = frame.read_reg(callee_v)?.clone();
-                    let args = collect_args(frame, args_start_v, arg_count)?;
-
-                    // Check whether the callee is the original built-in eval
-                    // by comparing the Rc pointer with the one stored in the
-                    // global environment under "eval".
-                    let is_builtin = if let JsValue::NativeFunction(ref callee_fn) = callee {
-                        if let Some(JsValue::NativeFunction(ref global_fn)) =
-                            frame.global_env.borrow().get("eval").cloned()
-                        {
-                            Rc::ptr_eq(callee_fn, global_fn)
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    };
-
-                    if is_builtin {
-                        // Direct eval semantics (ECMAScript §19.2.1.1).
-                        // Non-string arg → return as-is; no arg → undefined.
-                        let source = match args.first() {
-                            Some(JsValue::String(s)) => s.clone(),
-                            Some(other) => {
-                                frame.accumulator = other.clone();
-                                continue;
-                            }
-                            None => {
-                                frame.accumulator = JsValue::Undefined;
-                                continue;
-                            }
+                    Opcode::LdaSmi => {
+                        let Operand::Immediate(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaSmi", 0));
                         };
-                        frame.accumulator = crate::builtins::global::global_eval_direct(
-                            &source,
-                            Rc::clone(&frame.global_env),
-                        )?;
-                    } else {
-                        // Callee was reassigned — fall through to normal call.
+                        frame.accumulator = JsValue::Smi(v);
+                    }
+                    Opcode::LdaUndefined => {
+                        frame.accumulator = JsValue::Undefined;
+                    }
+                    Opcode::LdaNull => {
+                        frame.accumulator = JsValue::Null;
+                    }
+                    Opcode::LdaTrue => {
+                        frame.accumulator = JsValue::Boolean(true);
+                    }
+                    Opcode::LdaFalse => {
+                        frame.accumulator = JsValue::Boolean(false);
+                    }
+                    Opcode::LdaConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaConstant", 0));
+                        };
+                        let entry = frame.bytecode_array.get_constant(idx).ok_or_else(|| {
+                            StatorError::Internal(format!(
+                                "constant pool index {idx} out of bounds"
+                            ))
+                        })?;
+                        frame.accumulator = constant_to_value(entry);
+                    }
+
+                    // ── Register moves ─────────────────────────────────────────
+                    Opcode::Ldar => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("Ldar", 0));
+                        };
+                        frame.accumulator = frame.read_reg(v)?.clone();
+                    }
+                    Opcode::Star => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("Star", 0));
+                        };
+                        let val = frame.accumulator.clone();
+                        frame.write_reg(v, val)?;
+                    }
+                    Opcode::Mov => {
+                        let Operand::Register(src) = instr.operands[0] else {
+                            return Err(err_bad_operand("Mov", 0));
+                        };
+                        let Operand::Register(dst) = instr.operands[1] else {
+                            return Err(err_bad_operand("Mov", 1));
+                        };
+                        let val = frame.read_reg(src)?.clone();
+                        frame.write_reg(dst, val)?;
+                    }
+
+                    // ── Arithmetic ─────────────────────────────────────────────
+                    //
+                    // Convention (V8 Ignition): the bytecode generator evaluates
+                    // LHS → accumulator and saves RHS to a temporary register
+                    // before emitting the arithmetic opcode.  From the
+                    // interpreter's point of view: acc = acc <op> reg.
+                    Opcode::Add => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("Add", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        frame.accumulator = js_add(&frame.accumulator, &rhs)?;
+                    }
+                    Opcode::Sub => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("Sub", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        if frame.accumulator.is_bigint() || rhs.is_bigint() {
+                            let l = to_bigint(&frame.accumulator)?;
+                            let r = to_bigint(&rhs)?;
+                            frame.accumulator = JsValue::BigInt(l.wrapping_sub(r));
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            let rhs_n = rhs.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n - rhs_n);
+                        }
+                    }
+                    Opcode::Mul => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("Mul", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        if frame.accumulator.is_bigint() || rhs.is_bigint() {
+                            let l = to_bigint(&frame.accumulator)?;
+                            let r = to_bigint(&rhs)?;
+                            frame.accumulator = JsValue::BigInt(l.wrapping_mul(r));
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            let rhs_n = rhs.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n * rhs_n);
+                        }
+                    }
+                    Opcode::Div => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("Div", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        if frame.accumulator.is_bigint() || rhs.is_bigint() {
+                            let l = to_bigint(&frame.accumulator)?;
+                            let r = to_bigint(&rhs)?;
+                            if r == 0 {
+                                return Err(StatorError::RangeError(
+                                    "Division by zero".to_string(),
+                                ));
+                            }
+                            frame.accumulator = JsValue::BigInt(l / r);
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            let rhs_n = rhs.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n / rhs_n);
+                        }
+                    }
+                    Opcode::Mod => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("Mod", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        if frame.accumulator.is_bigint() || rhs.is_bigint() {
+                            let l = to_bigint(&frame.accumulator)?;
+                            let r = to_bigint(&rhs)?;
+                            if r == 0 {
+                                return Err(StatorError::RangeError(
+                                    "Division by zero".to_string(),
+                                ));
+                            }
+                            frame.accumulator = JsValue::BigInt(l % r);
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            let rhs_n = rhs.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n % rhs_n);
+                        }
+                    }
+                    Opcode::Exp => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("Exp", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        if frame.accumulator.is_bigint() || rhs.is_bigint() {
+                            let l = to_bigint(&frame.accumulator)?;
+                            let r = to_bigint(&rhs)?;
+                            if r < 0 {
+                                return Err(StatorError::RangeError(
+                                    "Exponent must be positive".to_string(),
+                                ));
+                            }
+                            frame.accumulator = JsValue::BigInt(bigint_pow(l, r as u32));
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            let rhs_n = rhs.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n.powf(rhs_n));
+                        }
+                    }
+                    Opcode::BitwiseOr => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("BitwiseOr", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        if frame.accumulator.is_bigint() || rhs.is_bigint() {
+                            let l = to_bigint(&frame.accumulator)?;
+                            let r = to_bigint(&rhs)?;
+                            frame.accumulator = JsValue::BigInt(l | r);
+                        } else {
+                            let lhs = frame.accumulator.to_number()? as i32;
+                            let rhs_i = rhs.to_number()? as i32;
+                            frame.accumulator = JsValue::Smi(lhs | rhs_i);
+                        }
+                    }
+                    Opcode::BitwiseXor => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("BitwiseXor", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        if frame.accumulator.is_bigint() || rhs.is_bigint() {
+                            let l = to_bigint(&frame.accumulator)?;
+                            let r = to_bigint(&rhs)?;
+                            frame.accumulator = JsValue::BigInt(l ^ r);
+                        } else {
+                            let lhs = frame.accumulator.to_number()? as i32;
+                            let rhs_i = rhs.to_number()? as i32;
+                            frame.accumulator = JsValue::Smi(lhs ^ rhs_i);
+                        }
+                    }
+                    Opcode::BitwiseAnd => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("BitwiseAnd", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        if frame.accumulator.is_bigint() || rhs.is_bigint() {
+                            let l = to_bigint(&frame.accumulator)?;
+                            let r = to_bigint(&rhs)?;
+                            frame.accumulator = JsValue::BigInt(l & r);
+                        } else {
+                            let lhs = frame.accumulator.to_number()? as i32;
+                            let rhs_i = rhs.to_number()? as i32;
+                            frame.accumulator = JsValue::Smi(lhs & rhs_i);
+                        }
+                    }
+                    Opcode::ShiftLeft => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("ShiftLeft", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        if frame.accumulator.is_bigint() || rhs.is_bigint() {
+                            let l = to_bigint(&frame.accumulator)?;
+                            let r = to_bigint(&rhs)?;
+                            frame.accumulator = JsValue::BigInt(l.wrapping_shl(r as u32));
+                        } else {
+                            let lhs = frame.accumulator.to_number()? as i32;
+                            let shift = (rhs.to_number()? as u32) & 0x1f;
+                            frame.accumulator = JsValue::Smi(lhs << shift);
+                        }
+                    }
+                    Opcode::ShiftRight => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("ShiftRight", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        if frame.accumulator.is_bigint() || rhs.is_bigint() {
+                            let l = to_bigint(&frame.accumulator)?;
+                            let r = to_bigint(&rhs)?;
+                            frame.accumulator = JsValue::BigInt(l.wrapping_shr(r as u32));
+                        } else {
+                            let lhs = frame.accumulator.to_number()? as i32;
+                            let shift = (rhs.to_number()? as u32) & 0x1f;
+                            frame.accumulator = JsValue::Smi(lhs >> shift);
+                        }
+                    }
+                    Opcode::ShiftRightLogical => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("ShiftRightLogical", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        let lhs = frame.accumulator.to_number()? as i32 as u32;
+                        let shift = (rhs.to_number()? as u32) & 0x1f;
+                        let result = lhs >> shift;
+                        frame.accumulator = number_to_jsvalue(result as f64);
+                    }
+
+                    // ── Smi immediate arithmetic ──────────────────────────────
+                    Opcode::AddSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("AddSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n.wrapping_add(i128::from(imm)));
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n + imm as f64);
+                        }
+                    }
+                    Opcode::SubSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("SubSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n.wrapping_sub(i128::from(imm)));
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n - imm as f64);
+                        }
+                    }
+                    Opcode::MulSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("MulSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n.wrapping_mul(i128::from(imm)));
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n * imm as f64);
+                        }
+                    }
+                    Opcode::DivSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("DivSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            if imm == 0 {
+                                return Err(StatorError::RangeError(
+                                    "Division by zero".to_string(),
+                                ));
+                            }
+                            frame.accumulator = JsValue::BigInt(n / i128::from(imm));
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n / imm as f64);
+                        }
+                    }
+                    Opcode::ModSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("ModSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            if imm == 0 {
+                                return Err(StatorError::RangeError(
+                                    "Division by zero".to_string(),
+                                ));
+                            }
+                            frame.accumulator = JsValue::BigInt(n % i128::from(imm));
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n % imm as f64);
+                        }
+                    }
+                    Opcode::ExpSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("ExpSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            if imm < 0 {
+                                return Err(StatorError::RangeError(
+                                    "Exponent must be positive".to_string(),
+                                ));
+                            }
+                            frame.accumulator = JsValue::BigInt(bigint_pow(*n, imm as u32));
+                        } else {
+                            let lhs_n = frame.accumulator.to_number()?;
+                            frame.accumulator = number_to_jsvalue(lhs_n.powf(imm as f64));
+                        }
+                    }
+                    Opcode::BitwiseOrSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("BitwiseOrSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n | i128::from(imm));
+                        } else {
+                            let lhs = frame.accumulator.to_number()? as i32;
+                            frame.accumulator = JsValue::Smi(lhs | imm);
+                        }
+                    }
+                    Opcode::BitwiseXorSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("BitwiseXorSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n ^ i128::from(imm));
+                        } else {
+                            let lhs = frame.accumulator.to_number()? as i32;
+                            frame.accumulator = JsValue::Smi(lhs ^ imm);
+                        }
+                    }
+                    Opcode::BitwiseAndSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("BitwiseAndSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n & i128::from(imm));
+                        } else {
+                            let lhs = frame.accumulator.to_number()? as i32;
+                            frame.accumulator = JsValue::Smi(lhs & imm);
+                        }
+                    }
+                    Opcode::ShiftLeftSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("ShiftLeftSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n.wrapping_shl(imm as u32));
+                        } else {
+                            let lhs = frame.accumulator.to_number()? as i32;
+                            let shift = (imm as u32) & 0x1f;
+                            frame.accumulator = JsValue::Smi(lhs << shift);
+                        }
+                    }
+                    Opcode::ShiftRightSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("ShiftRightSmi", 0));
+                        };
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n.wrapping_shr(imm as u32));
+                        } else {
+                            let lhs = frame.accumulator.to_number()? as i32;
+                            let shift = (imm as u32) & 0x1f;
+                            frame.accumulator = JsValue::Smi(lhs >> shift);
+                        }
+                    }
+                    Opcode::ShiftRightLogicalSmi => {
+                        let Operand::Immediate(imm) = instr.operands[0] else {
+                            return Err(err_bad_operand("ShiftRightLogicalSmi", 0));
+                        };
+                        let lhs = frame.accumulator.to_number()? as i32 as u32;
+                        let shift = (imm as u32) & 0x1f;
+                        let result = lhs >> shift;
+                        frame.accumulator = number_to_jsvalue(result as f64);
+                    }
+
+                    Opcode::Inc => {
+                        // operands[0] is a FeedbackSlot, ignored at runtime.
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n.wrapping_add(1));
+                        } else {
+                            let n = frame.accumulator.to_number()?;
+                            frame.accumulator = number_to_jsvalue(n + 1.0);
+                        }
+                    }
+                    Opcode::Dec => {
+                        // operands[0] is a FeedbackSlot, ignored at runtime.
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n.wrapping_sub(1));
+                        } else {
+                            let n = frame.accumulator.to_number()?;
+                            frame.accumulator = number_to_jsvalue(n - 1.0);
+                        }
+                    }
+
+                    // ── Comparisons ────────────────────────────────────────────
+                    Opcode::TestEqual => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestEqual", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        let result = abstract_eq(&frame.accumulator, &rhs);
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+                    Opcode::TestNotEqual => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestNotEqual", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        let result = !abstract_eq(&frame.accumulator, &rhs);
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+                    Opcode::TestEqualStrict => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestEqualStrict", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        let result = strict_eq(&frame.accumulator, &rhs);
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+                    Opcode::TestLessThan => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestLessThan", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        let result = js_less_than(&frame.accumulator, &rhs)?;
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+                    Opcode::TestGreaterThan => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestGreaterThan", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        // a > b  ≡  b < a
+                        let result = js_less_than(&rhs, &frame.accumulator)?;
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+                    Opcode::TestLessThanOrEqual => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestLessThanOrEqual", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        // a <= b  ≡  !(b < a)
+                        let result = !js_less_than(&rhs, &frame.accumulator)?;
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+                    Opcode::TestGreaterThanOrEqual => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestGreaterThanOrEqual", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        // a >= b  ≡  !(a < b)
+                        let result = !js_less_than(&frame.accumulator, &rhs)?;
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+                    Opcode::TestNull => {
+                        frame.accumulator = JsValue::Boolean(frame.accumulator.is_null());
+                    }
+                    Opcode::TestUndefined => {
+                        frame.accumulator = JsValue::Boolean(frame.accumulator.is_undefined());
+                    }
+
+                    // ── Logical / Boolean ──────────────────────────────────────
+                    Opcode::LogicalNot => {
+                        // `!acc` — the compiler emits this when acc is already a
+                        // boolean.  We coerce via ToBoolean for safety.
+                        frame.accumulator = JsValue::Boolean(!frame.accumulator.to_boolean());
+                    }
+                    Opcode::ToBooleanLogicalNot => {
+                        // `!ToBoolean(acc)` — explicit coercion before negation.
+                        frame.accumulator = JsValue::Boolean(!frame.accumulator.to_boolean());
+                    }
+
+                    // ── Control flow ───────────────────────────────────────────
+                    Opcode::Jump => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("Jump", 0));
+                        };
+                        frame.pc =
+                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                    }
+                    // JumpLoop [offset, loop_depth, slot] — same as unconditional Jump.
+                    //
+                    // OSR (on-stack replacement): every back-edge increments the
+                    // OSR counter.  Once the count exceeds OSR_LOOP_THRESHOLD the
+                    // enclosing function is compiled to baseline JIT (if it has not
+                    // been compiled already), so that the *next call* to this
+                    // function executes via native code.  Once the back-edge count
+                    // exceeds MAGLEV_OSR_LOOP_THRESHOLD a Maglev background
+                    // compilation is scheduled so that future calls use the
+                    // optimised tier.  At TURBOFAN_OSR_LOOP_THRESHOLD a Turbofan
+                    // background compilation is scheduled for the highest tier.
+                    Opcode::JumpLoop => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpLoop", 0));
+                        };
+                        frame.pc =
+                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        frame.osr_loop_count = frame.osr_loop_count.saturating_add(1);
+                        if frame.osr_loop_count >= OSR_LOOP_THRESHOLD
+                            && frame.bytecode_array.try_get_jit_code().is_none()
+                        {
+                            maybe_compile_baseline(&frame.bytecode_array);
+                        }
+                        if frame.osr_loop_count >= MAGLEV_OSR_LOOP_THRESHOLD {
+                            maybe_compile_maglev(&frame.bytecode_array);
+                        }
+                        if frame.osr_loop_count >= TURBOFAN_OSR_LOOP_THRESHOLD {
+                            maybe_compile_turbofan(&frame.bytecode_array);
+                        }
+                    }
+                    Opcode::JumpIfTrue => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfTrue", 0));
+                        };
+                        if matches!(frame.accumulator, JsValue::Boolean(true)) {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    Opcode::JumpIfFalse => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfFalse", 0));
+                        };
+                        if matches!(frame.accumulator, JsValue::Boolean(false)) {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    Opcode::JumpIfToBooleanTrue => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfToBooleanTrue", 0));
+                        };
+                        if frame.accumulator.to_boolean() {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    Opcode::JumpIfToBooleanFalse => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfToBooleanFalse", 0));
+                        };
+                        if !frame.accumulator.to_boolean() {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    Opcode::JumpIfNull => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfNull", 0));
+                        };
+                        if frame.accumulator.is_null() {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    Opcode::JumpIfNotNull => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfNotNull", 0));
+                        };
+                        if !frame.accumulator.is_null() {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    Opcode::JumpIfUndefined => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfUndefined", 0));
+                        };
+                        if frame.accumulator.is_undefined() {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    Opcode::JumpIfNotUndefined => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfNotUndefined", 0));
+                        };
+                        if !frame.accumulator.is_undefined() {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    Opcode::JumpIfUndefinedOrNull => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfUndefinedOrNull", 0));
+                        };
+                        if frame.accumulator.is_nullish() {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    Opcode::Return => {
+                        return Ok(frame.accumulator.clone());
+                    }
+
+                    // ── Closure creation ───────────────────────────────────────
+                    // CreateClosure [func_idx, slot, flags]: load a BytecodeArray
+                    // from the constant pool and wrap it as a callable function
+                    // value.  The slot and flags operands are feedback-vector
+                    // metadata and are ignored at runtime.
+                    Opcode::CreateClosure => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("CreateClosure", 0));
+                        };
+                        let entry = frame.bytecode_array.get_constant(idx).ok_or_else(|| {
+                            StatorError::Internal(format!(
+                                "CreateClosure: constant pool index {idx} out of bounds"
+                            ))
+                        })?;
+                        let ConstantPoolEntry::Function(ba) = entry else {
+                            return Err(StatorError::Internal(
+                                "CreateClosure: constant pool entry is not a Function".into(),
+                            ));
+                        };
+                        frame.accumulator = JsValue::Function(Rc::new((**ba).clone()));
+                    }
+
+                    // ── Function calls ─────────────────────────────────────────
+                    //
+                    // Convention for all Call* opcodes:
+                    //   – The callee register holds a JsValue::Function.
+                    //   – If the function is a generator (`ba.is_generator()` is
+                    //     true), a fresh GeneratorState is created and returned
+                    //     as JsValue::Generator without executing the body.
+                    //   – Otherwise, arguments are collected, a new frame is
+                    //     created, and the interpreter runs the body.
+                    //
+                    // CallAnyReceiver [callable, args_start, args_count, slot]:
+                    //   Plain call with undefined receiver.  args_start is the
+                    //   first argument register; arguments occupy the next
+                    //   args_count consecutive registers.
+                    Opcode::CallAnyReceiver => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallAnyReceiver", 0));
+                        };
+                        let Operand::Register(args_start_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("CallAnyReceiver", 1));
+                        };
+                        let Operand::RegisterCount(arg_count) = instr.operands[2] else {
+                            return Err(err_bad_operand("CallAnyReceiver", 2));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
                         match callee {
                             JsValue::Function(ba) => {
                                 if ba.is_generator() {
                                     frame.accumulator =
                                         JsValue::Generator(GeneratorState::new((*ba).clone()));
+                                } else if ba.is_async() {
+                                    let args = collect_args(frame, args_start_v, arg_count)?;
+                                    frame.accumulator =
+                                        Interpreter::run_async_function((*ba).clone(), args)?;
                                 } else {
+                                    let args = collect_args(frame, args_start_v, arg_count)?;
+                                    // ── Tiering ──────────────────────────────────
+                                    let count = ba.increment_invocation_count();
+                                    if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none()
+                                    {
+                                        maybe_compile_baseline(&ba);
+                                    }
+                                    if count >= MAGLEV_TIERING_THRESHOLD {
+                                        maybe_compile_maglev(&ba);
+                                    }
+                                    if count >= TURBOFAN_TIERING_THRESHOLD {
+                                        maybe_compile_turbofan(&ba);
+                                    }
+                                    let mut tried_jit = false;
+                                    if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
+                                        frame.accumulator = jit_result?;
+                                        tried_jit = true;
+                                    }
+                                    if !tried_jit {
+                                        let mut callee_frame = InterpreterFrame::new_with_globals(
+                                            (*ba).clone(),
+                                            args,
+                                            Rc::clone(&frame.global_env),
+                                        );
+                                        push_call_frame("<anonymous>")?;
+                                        let result = Interpreter::run(&mut callee_frame);
+                                        pop_call_frame();
+                                        frame.accumulator = result?;
+                                    }
+                                }
+                            }
+                            JsValue::NativeFunction(f) => {
+                                let args = collect_args(frame, args_start_v, arg_count)?;
+                                frame.accumulator = f(args)?;
+                            }
+                            JsValue::PlainObject(ref map) => {
+                                if let Some(JsValue::NativeFunction(f)) =
+                                    map.borrow().get("__call__").cloned()
+                                {
+                                    let args = collect_args(frame, args_start_v, arg_count)?;
+                                    frame.accumulator = f(args)?;
+                                } else {
+                                    return Err(StatorError::TypeError(
+                                    "CallAnyReceiver: callee is not a function (got PlainObject)"
+                                        .to_string(),
+                                ));
+                                }
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "CallAnyReceiver: callee is not a function (got {other:?})"
+                                )));
+                            }
+                        }
+                    }
+
+                    // ── Tail call (proper tail calls, ES2015) ─────────────
+                    //
+                    // TailCall [callable, args_start, args_count, slot]:
+                    //   Same operand layout as CallAnyReceiver, but the
+                    //   interpreter reuses the current frame instead of
+                    //   creating a new one, preventing stack growth.
+                    Opcode::TailCall => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TailCall", 0));
+                        };
+                        let Operand::Register(args_start_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("TailCall", 1));
+                        };
+                        let Operand::RegisterCount(arg_count) = instr.operands[2] else {
+                            return Err(err_bad_operand("TailCall", 2));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
+                        match callee {
+                            JsValue::Function(ba) => {
+                                if ba.is_generator() || ba.is_async() {
+                                    // Generators/async cannot be tail-called;
+                                    // fall back to a normal call.
+                                    let args = collect_args(frame, args_start_v, arg_count)?;
+                                    if ba.is_generator() {
+                                        frame.accumulator =
+                                            JsValue::Generator(GeneratorState::new((*ba).clone()));
+                                    } else {
+                                        frame.accumulator =
+                                            Interpreter::run_async_function((*ba).clone(), args)?;
+                                    }
+                                } else {
+                                    let args = collect_args(frame, args_start_v, arg_count)?;
+                                    // ── Tiering ──────────────────────────────
+                                    let count = ba.increment_invocation_count();
+                                    if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none()
+                                    {
+                                        maybe_compile_baseline(&ba);
+                                    }
+                                    if count >= MAGLEV_TIERING_THRESHOLD {
+                                        maybe_compile_maglev(&ba);
+                                    }
+                                    if count >= TURBOFAN_TIERING_THRESHOLD {
+                                        maybe_compile_turbofan(&ba);
+                                    }
+                                    let mut tried_jit = false;
+                                    if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
+                                        frame.accumulator = jit_result?;
+                                        tried_jit = true;
+                                    }
+                                    if !tried_jit {
+                                        // ── Proper tail call: reuse the frame ─
+                                        let new_ba = (*ba).clone();
+                                        let param_count = new_ba.parameter_count() as usize;
+                                        let frame_size = new_ba.frame_size() as usize;
+                                        let total_regs = param_count + frame_size;
+                                        frame.bytecode_array = new_ba;
+                                        frame.registers.clear();
+                                        frame.registers.resize(total_regs, JsValue::Undefined);
+                                        for (i, arg) in
+                                            args.into_iter().enumerate().take(param_count)
+                                        {
+                                            frame.registers[i] = arg;
+                                        }
+                                        frame.accumulator = JsValue::Undefined;
+                                        frame.pc = 0;
+                                        frame.context = None;
+                                        continue 'tail_call;
+                                    }
+                                }
+                            }
+                            JsValue::NativeFunction(f) => {
+                                let args = collect_args(frame, args_start_v, arg_count)?;
+                                frame.accumulator = f(args)?;
+                            }
+                            JsValue::PlainObject(ref map) => {
+                                if let Some(JsValue::NativeFunction(f)) =
+                                    map.borrow().get("__call__").cloned()
+                                {
+                                    let args = collect_args(frame, args_start_v, arg_count)?;
+                                    frame.accumulator = f(args)?;
+                                } else {
+                                    return Err(StatorError::TypeError(
+                                        "TailCall: callee is not a function (got PlainObject)"
+                                            .to_string(),
+                                    ));
+                                }
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "TailCall: callee is not a function (got {other:?})"
+                                )));
+                            }
+                        }
+                    }
+
+                    // CallUndefinedReceiver0 [callable, slot]:
+                    //   Call with undefined receiver and zero arguments.
+                    Opcode::CallUndefinedReceiver0 => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallUndefinedReceiver0", 0));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
+                        match callee {
+                            JsValue::Function(ba) => {
+                                if ba.is_generator() {
+                                    frame.accumulator =
+                                        JsValue::Generator(GeneratorState::new((*ba).clone()));
+                                } else if ba.is_async() {
+                                    frame.accumulator =
+                                        Interpreter::run_async_function((*ba).clone(), vec![])?;
+                                } else {
+                                    let args: Vec<JsValue> = vec![];
+                                    let count = ba.increment_invocation_count();
+                                    if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none()
+                                    {
+                                        maybe_compile_baseline(&ba);
+                                    }
+                                    if count >= MAGLEV_TIERING_THRESHOLD {
+                                        maybe_compile_maglev(&ba);
+                                    }
+                                    if count >= TURBOFAN_TIERING_THRESHOLD {
+                                        maybe_compile_turbofan(&ba);
+                                    }
+                                    let mut tried_jit = false;
+                                    if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
+                                        frame.accumulator = jit_result?;
+                                        tried_jit = true;
+                                    }
+                                    if !tried_jit {
+                                        let mut callee_frame = InterpreterFrame::new_with_globals(
+                                            (*ba).clone(),
+                                            args,
+                                            Rc::clone(&frame.global_env),
+                                        );
+                                        push_call_frame("<anonymous>")?;
+                                        let result = Interpreter::run(&mut callee_frame);
+                                        pop_call_frame();
+                                        frame.accumulator = result?;
+                                    }
+                                }
+                            }
+                            JsValue::NativeFunction(f) => {
+                                frame.accumulator = f(vec![])?;
+                            }
+                            JsValue::PlainObject(ref map) => {
+                                if let Some(JsValue::NativeFunction(f)) =
+                                    map.borrow().get("__call__").cloned()
+                                {
+                                    frame.accumulator = f(vec![])?;
+                                } else {
+                                    return Err(StatorError::TypeError(
+                                    "CallUndefinedReceiver0: callee is not a function (got PlainObject)".to_string()
+                                ));
+                                }
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "CallUndefinedReceiver0: callee is not a function (got {other:?})"
+                                )));
+                            }
+                        }
+                    }
+
+                    // CallUndefinedReceiver1 [callable, arg1, slot]:
+                    //   Call with undefined receiver and one argument.
+                    Opcode::CallUndefinedReceiver1 => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallUndefinedReceiver1", 0));
+                        };
+                        let Operand::Register(arg1_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("CallUndefinedReceiver1", 1));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
+                        match callee {
+                            JsValue::Function(ba) => {
+                                if ba.is_generator() {
+                                    frame.accumulator =
+                                        JsValue::Generator(GeneratorState::new((*ba).clone()));
+                                } else if ba.is_async() {
+                                    let arg1 = frame.read_reg(arg1_v)?.clone();
+                                    frame.accumulator =
+                                        Interpreter::run_async_function((*ba).clone(), vec![arg1])?;
+                                } else {
+                                    let arg1 = frame.read_reg(arg1_v)?.clone();
+                                    let args = vec![arg1];
+                                    let count = ba.increment_invocation_count();
+                                    if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none()
+                                    {
+                                        maybe_compile_baseline(&ba);
+                                    }
+                                    if count >= MAGLEV_TIERING_THRESHOLD {
+                                        maybe_compile_maglev(&ba);
+                                    }
+                                    if count >= TURBOFAN_TIERING_THRESHOLD {
+                                        maybe_compile_turbofan(&ba);
+                                    }
+                                    let mut tried_jit = false;
+                                    if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
+                                        frame.accumulator = jit_result?;
+                                        tried_jit = true;
+                                    }
+                                    if !tried_jit {
+                                        let mut callee_frame = InterpreterFrame::new_with_globals(
+                                            (*ba).clone(),
+                                            args,
+                                            Rc::clone(&frame.global_env),
+                                        );
+                                        push_call_frame("<anonymous>")?;
+                                        let result = Interpreter::run(&mut callee_frame);
+                                        pop_call_frame();
+                                        frame.accumulator = result?;
+                                    }
+                                }
+                            }
+                            JsValue::NativeFunction(f) => {
+                                let arg1 = frame.read_reg(arg1_v)?.clone();
+                                frame.accumulator = f(vec![arg1])?;
+                            }
+                            JsValue::PlainObject(ref map) => {
+                                if let Some(JsValue::NativeFunction(f)) =
+                                    map.borrow().get("__call__").cloned()
+                                {
+                                    let arg1 = frame.read_reg(arg1_v)?.clone();
+                                    frame.accumulator = f(vec![arg1])?;
+                                } else {
+                                    return Err(StatorError::TypeError(
+                                    "CallUndefinedReceiver1: callee is not a function (got PlainObject)".to_string()
+                                ));
+                                }
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "CallUndefinedReceiver1: callee is not a function (got {other:?})"
+                                )));
+                            }
+                        }
+                    }
+
+                    // CallUndefinedReceiver2 [callable, arg1, arg2, slot]:
+                    //   Call with undefined receiver and two arguments.
+                    Opcode::CallUndefinedReceiver2 => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallUndefinedReceiver2", 0));
+                        };
+                        let Operand::Register(arg1_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("CallUndefinedReceiver2", 1));
+                        };
+                        let Operand::Register(arg2_v) = instr.operands[2] else {
+                            return Err(err_bad_operand("CallUndefinedReceiver2", 2));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
+                        match callee {
+                            JsValue::Function(ba) => {
+                                if ba.is_generator() {
+                                    frame.accumulator =
+                                        JsValue::Generator(GeneratorState::new((*ba).clone()));
+                                } else if ba.is_async() {
+                                    let arg1 = frame.read_reg(arg1_v)?.clone();
+                                    let arg2 = frame.read_reg(arg2_v)?.clone();
+                                    frame.accumulator = Interpreter::run_async_function(
+                                        (*ba).clone(),
+                                        vec![arg1, arg2],
+                                    )?;
+                                } else {
+                                    let arg1 = frame.read_reg(arg1_v)?.clone();
+                                    let arg2 = frame.read_reg(arg2_v)?.clone();
+                                    let args = vec![arg1, arg2];
+                                    // ── Tiering ──────────────────────────────────
+                                    let count = ba.increment_invocation_count();
+                                    if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none()
+                                    {
+                                        maybe_compile_baseline(&ba);
+                                    }
+                                    if count >= MAGLEV_TIERING_THRESHOLD {
+                                        maybe_compile_maglev(&ba);
+                                    }
+                                    if count >= TURBOFAN_TIERING_THRESHOLD {
+                                        maybe_compile_turbofan(&ba);
+                                    }
+                                    let mut tried_jit = false;
+                                    if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
+                                        frame.accumulator = jit_result?;
+                                        tried_jit = true;
+                                    }
+                                    if !tried_jit {
+                                        let mut callee_frame = InterpreterFrame::new_with_globals(
+                                            (*ba).clone(),
+                                            args,
+                                            Rc::clone(&frame.global_env),
+                                        );
+                                        push_call_frame("<anonymous>")?;
+                                        let result = Interpreter::run(&mut callee_frame);
+                                        pop_call_frame();
+                                        frame.accumulator = result?;
+                                    }
+                                }
+                            }
+                            JsValue::NativeFunction(f) => {
+                                let arg1 = frame.read_reg(arg1_v)?.clone();
+                                let arg2 = frame.read_reg(arg2_v)?.clone();
+                                frame.accumulator = f(vec![arg1, arg2])?;
+                            }
+                            JsValue::PlainObject(ref map) => {
+                                if let Some(JsValue::NativeFunction(f)) =
+                                    map.borrow().get("__call__").cloned()
+                                {
+                                    let arg1 = frame.read_reg(arg1_v)?.clone();
+                                    let arg2 = frame.read_reg(arg2_v)?.clone();
+                                    frame.accumulator = f(vec![arg1, arg2])?;
+                                } else {
+                                    return Err(StatorError::TypeError(
+                                    "CallUndefinedReceiver2: callee is not a function (got PlainObject)".to_string()
+                                ));
+                                }
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "CallUndefinedReceiver2: callee is not a function (got {other:?})"
+                                )));
+                            }
+                        }
+                    }
+
+                    // CallProperty [callable, recv, args_count, slot]:
+                    //   Method call.  The receiver ("this") is in the register
+                    //   immediately before the callee register in the register
+                    //   file.  Arguments occupy the args_count consecutive
+                    //   registers starting one past the callee register.
+                    //   The receiver is stored in the callee frame's context so
+                    //   that the callee can read it if needed.
+                    Opcode::CallProperty => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallProperty", 0));
+                        };
+                        let Operand::Register(recv_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("CallProperty", 1));
+                        };
+                        let Operand::RegisterCount(arg_count) = instr.operands[2] else {
+                            return Err(err_bad_operand("CallProperty", 2));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
+                        // Arguments reside in the registers immediately following
+                        // the callee register in the flat register file.
+                        let callee_flat = frame.reg_index(callee_v)?;
+                        let args = (0..arg_count as usize)
+                            .map(|i| frame.registers[callee_flat + 1 + i].clone())
+                            .collect::<Vec<_>>();
+                        match callee {
+                            JsValue::Function(ba) => {
+                                let this_val = frame.read_reg(recv_v)?.clone();
+                                // ── Tiering ──────────────────────────────────────
+                                let count = ba.increment_invocation_count();
+                                if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none() {
+                                    maybe_compile_baseline(&ba);
+                                }
+                                if count >= MAGLEV_TIERING_THRESHOLD {
+                                    maybe_compile_maglev(&ba);
+                                }
+                                if count >= TURBOFAN_TIERING_THRESHOLD {
+                                    maybe_compile_turbofan(&ba);
+                                }
+                                let mut tried_jit = false;
+                                if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
+                                    frame.accumulator = jit_result?;
+                                    tried_jit = true;
+                                }
+                                if !tried_jit {
                                     let mut callee_frame = InterpreterFrame::new_with_globals(
                                         (*ba).clone(),
                                         args,
                                         Rc::clone(&frame.global_env),
                                     );
-                                    let _ = push_call_frame("<eval-fallback>");
+                                    callee_frame.context = Some(this_val);
+                                    push_call_frame("<anonymous>")?;
                                     let result = Interpreter::run(&mut callee_frame);
                                     pop_call_frame();
                                     frame.accumulator = result?;
@@ -4133,28 +2054,2256 @@ impl Interpreter {
                                     frame.accumulator = f(args)?;
                                 } else {
                                     return Err(StatorError::TypeError(
-                                        "CallDirectEval: callee is not a function (got PlainObject)"
+                                        "CallProperty: callee is not a function (got PlainObject)"
                                             .to_string(),
                                     ));
                                 }
                             }
                             other => {
                                 return Err(StatorError::TypeError(format!(
-                                    "CallDirectEval: callee is not a function (got {other:?})"
+                                    "CallProperty: callee is not a function (got {other:?})"
                                 )));
                             }
                         }
                     }
-                }
 
-                // ── Unimplemented ──────────────────────────────────────────
-                other => {
-                    return Err(StatorError::Internal(format!(
-                        "unimplemented opcode: {other:?}"
-                    )));
+                    // CallWithSpread [callable, args_start, args_count, slot]:
+                    //   Call with a spread argument.  For the interpreter's
+                    //   purposes we treat this identically to CallAnyReceiver;
+                    //   the spread expansion has already been resolved by the
+                    //   compiler into the argument registers.
+                    Opcode::CallWithSpread => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallWithSpread", 0));
+                        };
+                        let Operand::Register(args_start_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("CallWithSpread", 1));
+                        };
+                        let Operand::RegisterCount(arg_count) = instr.operands[2] else {
+                            return Err(err_bad_operand("CallWithSpread", 2));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
+                        match callee {
+                            JsValue::Function(ba) => {
+                                let args = collect_args(frame, args_start_v, arg_count)?;
+                                // ── Tiering ──────────────────────────────────────
+                                let count = ba.increment_invocation_count();
+                                if count >= TIERING_THRESHOLD && ba.try_get_jit_code().is_none() {
+                                    maybe_compile_baseline(&ba);
+                                }
+                                if count >= MAGLEV_TIERING_THRESHOLD {
+                                    maybe_compile_maglev(&ba);
+                                }
+                                if count >= TURBOFAN_TIERING_THRESHOLD {
+                                    maybe_compile_turbofan(&ba);
+                                }
+                                let mut tried_jit = false;
+                                if let Some(jit_result) = try_execute_best_jit(&ba, &args) {
+                                    frame.accumulator = jit_result?;
+                                    tried_jit = true;
+                                }
+                                if !tried_jit {
+                                    let mut callee_frame = InterpreterFrame::new_with_globals(
+                                        (*ba).clone(),
+                                        args,
+                                        Rc::clone(&frame.global_env),
+                                    );
+                                    push_call_frame("<anonymous>")?;
+                                    let result = Interpreter::run(&mut callee_frame);
+                                    pop_call_frame();
+                                    frame.accumulator = result?;
+                                }
+                            }
+                            JsValue::NativeFunction(f) => {
+                                let args = collect_args(frame, args_start_v, arg_count)?;
+                                frame.accumulator = f(args)?;
+                            }
+                            JsValue::PlainObject(ref map) => {
+                                if let Some(JsValue::NativeFunction(f)) =
+                                    map.borrow().get("__call__").cloned()
+                                {
+                                    let args = collect_args(frame, args_start_v, arg_count)?;
+                                    frame.accumulator = f(args)?;
+                                } else {
+                                    return Err(StatorError::TypeError(
+                                    "CallWithSpread: callee is not a function (got PlainObject)"
+                                        .to_string(),
+                                ));
+                                }
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "CallWithSpread: callee is not a function (got {other:?})"
+                                )));
+                            }
+                        }
+                    }
+
+                    // ── Construct ──────────────────────────────────────────────
+                    //
+                    // Construct [constructor, args_start, args_count, slot]:
+                    //   `new constructor(args…)`.  Executes the constructor body
+                    //   and wires `[[Prototype]]` on the resulting object.
+                    Opcode::Construct | Opcode::ConstructWithSpread => {
+                        let Operand::Register(ctor_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("Construct", 0));
+                        };
+                        let Operand::Register(args_start_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("Construct", 1));
+                        };
+                        let Operand::RegisterCount(arg_count) = instr.operands[2] else {
+                            return Err(err_bad_operand("Construct", 2));
+                        };
+                        let ctor = frame.read_reg(ctor_v)?.clone();
+                        // Resolve constructor's "prototype" for [[Prototype]] wiring.
+                        let ctor_proto = proto_lookup(&ctor, "prototype");
+                        match ctor {
+                            JsValue::Function(ba) => {
+                                let args = collect_args(frame, args_start_v, arg_count)?;
+                                let mut callee_frame = InterpreterFrame::new_with_globals(
+                                    (*ba).clone(),
+                                    args,
+                                    Rc::clone(&frame.global_env),
+                                );
+                                push_call_frame("<anonymous>")?;
+                                let result = Interpreter::run(&mut callee_frame);
+                                pop_call_frame();
+                                let val = result?;
+                                frame.accumulator = wire_construct_prototype(val, &ctor_proto);
+                            }
+                            JsValue::NativeFunction(f) => {
+                                let args = collect_args(frame, args_start_v, arg_count)?;
+                                frame.accumulator = f(args)?;
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "Construct: constructor is not a function (got {other:?})"
+                                )));
+                            }
+                        }
+                    }
+
+                    // ── Context management ─────────────────────────────────────
+                    //
+                    // PushContext [reg]: the accumulator holds the new context
+                    //   value; the old context is saved into `reg` so it can be
+                    //   restored later by PopContext.
+                    //
+                    //   Registers hold `JsValue`, not `Option<JsValue>`, so an
+                    //   absent context is encoded as `JsValue::Undefined` in the
+                    //   saved register.  PopContext inverts this by mapping
+                    //   `Undefined` back to `None`.
+                    Opcode::PushContext => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("PushContext", 0));
+                        };
+                        // Encode None as Undefined so it can be stored in a register.
+                        let old_ctx = frame.context.take().unwrap_or(JsValue::Undefined);
+                        frame.write_reg(v, old_ctx)?;
+                        frame.context = Some(frame.accumulator.clone());
+                    }
+
+                    // PopContext [reg]: restore the context that was previously
+                    //   saved in `reg` by PushContext.
+                    //   `Undefined` in the register means there was no context.
+                    Opcode::PopContext => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("PopContext", 0));
+                        };
+                        let saved = frame.read_reg(v)?.clone();
+                        frame.context = if saved.is_undefined() {
+                            None
+                        } else {
+                            Some(saved)
+                        };
+                    }
+
+                    // ── Context slot access ────────────────────────────────────
+                    //
+                    // LdaContextSlot [ctx_reg, slot_idx, depth]:
+                    //   Load the value from `context[slot_idx]` after walking
+                    //   `depth` levels up the context chain starting from the
+                    //   context in `ctx_reg`.
+                    Opcode::LdaContextSlot | Opcode::LdaImmutableContextSlot => {
+                        let Operand::Register(ctx_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaContextSlot", 0));
+                        };
+                        let Operand::ConstantPoolIdx(slot_idx) = instr.operands[1] else {
+                            return Err(err_bad_operand("LdaContextSlot", 1));
+                        };
+                        let Operand::Immediate(depth) = instr.operands[2] else {
+                            return Err(err_bad_operand("LdaContextSlot", 2));
+                        };
+                        let ctx_val = frame.read_reg(ctx_v)?.clone();
+                        let ctx = extract_context(&ctx_val, "LdaContextSlot")?;
+                        let target = walk_context_chain(&ctx, depth as u32, "LdaContextSlot")?;
+                        let borrowed = target.borrow();
+                        let slot = slot_idx as usize;
+                        frame.accumulator = borrowed
+                            .slots
+                            .get(slot)
+                            .cloned()
+                            .unwrap_or(JsValue::Undefined);
+                    }
+
+                    // LdaCurrentContextSlot [slot_idx]:
+                    //   Shorthand for LdaContextSlot with depth=0, using the
+                    //   frame's current context.
+                    Opcode::LdaCurrentContextSlot | Opcode::LdaImmutableCurrentContextSlot => {
+                        let Operand::ConstantPoolIdx(slot_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaCurrentContextSlot", 0));
+                        };
+                        let ctx_val = frame
+                            .context
+                            .as_ref()
+                            .ok_or_else(|| {
+                                StatorError::Internal(
+                                    "LdaCurrentContextSlot: no active context".into(),
+                                )
+                            })?
+                            .clone();
+                        let ctx = extract_context(&ctx_val, "LdaCurrentContextSlot")?;
+                        let borrowed = ctx.borrow();
+                        let slot = slot_idx as usize;
+                        frame.accumulator = borrowed
+                            .slots
+                            .get(slot)
+                            .cloned()
+                            .unwrap_or(JsValue::Undefined);
+                    }
+
+                    // StaContextSlot [ctx_reg, slot_idx, depth]:
+                    //   Store the accumulator into `context[slot_idx]` after
+                    //   walking `depth` levels up the context chain.
+                    Opcode::StaContextSlot => {
+                        let Operand::Register(ctx_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("StaContextSlot", 0));
+                        };
+                        let Operand::ConstantPoolIdx(slot_idx) = instr.operands[1] else {
+                            return Err(err_bad_operand("StaContextSlot", 1));
+                        };
+                        let Operand::Immediate(depth) = instr.operands[2] else {
+                            return Err(err_bad_operand("StaContextSlot", 2));
+                        };
+                        let ctx_val = frame.read_reg(ctx_v)?.clone();
+                        let ctx = extract_context(&ctx_val, "StaContextSlot")?;
+                        let target = walk_context_chain(&ctx, depth as u32, "StaContextSlot")?;
+                        let mut borrowed = target.borrow_mut();
+                        let slot = slot_idx as usize;
+                        if slot >= borrowed.slots.len() {
+                            borrowed.slots.resize(slot + 1, JsValue::Undefined);
+                        }
+                        borrowed.slots[slot] = frame.accumulator.clone();
+                    }
+
+                    // StaCurrentContextSlot [slot_idx]:
+                    //   Shorthand for StaContextSlot with depth=0.
+                    Opcode::StaCurrentContextSlot => {
+                        let Operand::ConstantPoolIdx(slot_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("StaCurrentContextSlot", 0));
+                        };
+                        let ctx_val = frame
+                            .context
+                            .as_ref()
+                            .ok_or_else(|| {
+                                StatorError::Internal(
+                                    "StaCurrentContextSlot: no active context".into(),
+                                )
+                            })?
+                            .clone();
+                        let ctx = extract_context(&ctx_val, "StaCurrentContextSlot")?;
+                        let mut borrowed = ctx.borrow_mut();
+                        let slot = slot_idx as usize;
+                        if slot >= borrowed.slots.len() {
+                            borrowed.slots.resize(slot + 1, JsValue::Undefined);
+                        }
+                        borrowed.slots[slot] = frame.accumulator.clone();
+                    }
+
+                    // ── Context construction ───────────────────────────────────
+                    //
+                    // CreateFunctionContext [scope_idx, slot_count]:
+                    //   Create a new context with `slot_count` slots for a
+                    //   function scope.  The current frame context (if any)
+                    //   becomes the parent.  The new context is placed in the
+                    //   accumulator but is NOT automatically installed — the
+                    //   caller typically follows with `PushContext`.
+                    Opcode::CreateFunctionContext => {
+                        let Operand::Immediate(slot_count) = instr.operands[1] else {
+                            return Err(err_bad_operand("CreateFunctionContext", 1));
+                        };
+                        let parent = match &frame.context {
+                            Some(JsValue::Context(ctx)) => Some(Rc::clone(ctx)),
+                            _ => None,
+                        };
+                        let ctx = JsContext::new(slot_count as usize, parent);
+                        frame.accumulator = JsValue::Context(ctx);
+                    }
+
+                    // CreateBlockContext [scope_idx]:
+                    //   Create a new context for a block scope.  Like
+                    //   CreateFunctionContext but the slot count is not encoded
+                    //   in the operand — we default to 0 slots and let
+                    //   StaContextSlot grow them on demand.
+                    Opcode::CreateBlockContext => {
+                        let parent = match &frame.context {
+                            Some(JsValue::Context(ctx)) => Some(Rc::clone(ctx)),
+                            _ => None,
+                        };
+                        let ctx = JsContext::new(0, parent);
+                        frame.accumulator = JsValue::Context(ctx);
+                    }
+
+                    // CreateEvalContext [scope_idx, slot_count]:
+                    //   Create a new context for an eval scope.
+                    Opcode::CreateEvalContext => {
+                        let Operand::Immediate(slot_count) = instr.operands[1] else {
+                            return Err(err_bad_operand("CreateEvalContext", 1));
+                        };
+                        let parent = match &frame.context {
+                            Some(JsValue::Context(ctx)) => Some(Rc::clone(ctx)),
+                            _ => None,
+                        };
+                        let ctx = JsContext::new(slot_count as usize, parent);
+                        frame.accumulator = JsValue::Context(ctx);
+                    }
+
+                    // CreateCatchContext [exception_reg, scope_idx]:
+                    //   Create a new context for a catch block, with the caught
+                    //   exception as slot 0.
+                    Opcode::CreateCatchContext => {
+                        let Operand::Register(exc_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CreateCatchContext", 0));
+                        };
+                        let exception = frame.read_reg(exc_v)?.clone();
+                        let parent = match &frame.context {
+                            Some(JsValue::Context(ctx)) => Some(Rc::clone(ctx)),
+                            _ => None,
+                        };
+                        let ctx = JsContext::new(1, parent);
+                        ctx.borrow_mut().slots[0] = exception;
+                        frame.accumulator = JsValue::Context(ctx);
+                    }
+
+                    // CreateWithContext [obj_reg, scope_idx]:
+                    //   Create a new context for a `with` statement.  The
+                    //   object is stored as slot 0 of the new context.
+                    Opcode::CreateWithContext => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CreateWithContext", 0));
+                        };
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        let parent = match &frame.context {
+                            Some(JsValue::Context(ctx)) => Some(Rc::clone(ctx)),
+                            _ => None,
+                        };
+                        let ctx = JsContext::new(1, parent);
+                        ctx.borrow_mut().slots[0] = obj;
+                        frame.accumulator = JsValue::Context(ctx);
+                    }
+
+                    // ── Exception handling ─────────────────────────────────────
+                    //
+                    // Throw / ReThrow: the value to throw is in the accumulator.
+                    // Walk the handler table looking for the innermost entry whose
+                    // [try_start, try_end) range covers the current instruction
+                    // (pc was already incremented, so the throwing instruction
+                    // index is `frame.pc - 1`).  If a handler is found, load
+                    // the thrown value into the accumulator and jump to the
+                    // handler entry point.  Otherwise, propagate the exception
+                    // as a `StatorError::JsException` to the caller.
+                    Opcode::Throw | Opcode::ReThrow => {
+                        let thrown = frame.accumulator.clone();
+                        let throw_idx = (frame.pc - 1) as u32;
+                        if let Some(handler_pc) = find_handler(throw_idx, &handler_table) {
+                            frame.accumulator = thrown;
+                            frame.pc = handler_pc;
+                            continue;
+                        }
+                        // ── pause-on-exceptions ───────────────────────────────
+                        // When a debugger is attached with pause_on_exceptions
+                        // enabled, suspend execution *before* the exception
+                        // propagates.  Back up the program counter to the Throw
+                        // instruction so that resuming re-executes it and lets the
+                        // exception propagate normally (skip_next prevents a
+                        // double-pause on the re-execution).
+                        let throw_offset = byte_offsets[throw_idx as usize] as u32;
+                        if let Some(pause_err) = ACTIVE_DEBUGGER.with(|d| {
+                            let opt = d.borrow();
+                            opt.as_ref().and_then(|rc| {
+                                let mut dbg = rc.borrow_mut();
+                                // consume_exception_resume returns true on a
+                                // resume re-execution — skip the pause in that
+                                // case so the exception can propagate.
+                                if dbg.pause_on_exceptions && !dbg.consume_exception_resume() {
+                                    frame.pc = throw_idx as usize; // back up
+                                    Some(dbg.on_exception(throw_offset))
+                                } else {
+                                    None
+                                }
+                            })
+                        }) {
+                            return Err(pause_err);
+                        }
+                        // No handler in this frame — serialise the thrown value and
+                        // propagate it as a `StatorError::JsException` to the caller.
+                        let msg = error_message_from_value(&thrown);
+                        return Err(StatorError::JsException(msg));
+                    }
+
+                    // ── Ignored no-ops ─────────────────────────────────────────
+                    // These opcodes carry metadata that does not affect execution.
+                    Opcode::StackCheck
+                    | Opcode::SetExpressionPosition
+                    | Opcode::SetExpressionPositionFromEnd => {}
+
+                    // ── Global variable access ──────────────────────────────────
+                    //
+                    // LdaGlobal [name_idx, feedback_slot]:
+                    //   Load the global variable named by the string at
+                    //   `constant_pool[name_idx]` into the accumulator.
+                    //   Produces `undefined` when the name is not found.
+                    Opcode::LdaGlobal | Opcode::LdaGlobalInsideTypeof => {
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaGlobal", 0));
+                        };
+                        let name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "LdaGlobal: constant is not a string".into(),
+                                ));
+                            }
+                        };
+                        frame.accumulator = frame
+                            .global_env
+                            .borrow()
+                            .get(&name)
+                            .cloned()
+                            .unwrap_or(JsValue::Undefined);
+                    }
+
+                    // StaGlobal [name_idx, feedback_slot]:
+                    //   Store the accumulator to the global variable named by
+                    //   `constant_pool[name_idx]`.
+                    Opcode::StaGlobal => {
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("StaGlobal", 0));
+                        };
+                        let name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "StaGlobal: constant is not a string".into(),
+                                ));
+                            }
+                        };
+                        let val = frame.accumulator.clone();
+                        frame.global_env.borrow_mut().insert(name, val);
+                    }
+
+                    // LdaNamedProperty [object_reg, name_idx, feedback_slot]:
+                    //   Load the named property from the object in `object_reg`.
+                    //   Supports `PlainObject` (property map) and falls back to
+                    //   `undefined` for other value types.
+                    Opcode::LdaNamedProperty => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaNamedProperty", 0));
+                        };
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[1] else {
+                            return Err(err_bad_operand("LdaNamedProperty", 1));
+                        };
+                        let prop_name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "LdaNamedProperty: property name is not a string".into(),
+                                ));
+                            }
+                        };
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        frame.accumulator = proto_lookup(&obj, &prop_name);
+                    }
+
+                    // StaNamedProperty [object_reg, name_idx, feedback_slot]:
+                    //   Store the accumulator into the named property on the object
+                    //   held in `object_reg`.  Supports `PlainObject` (property
+                    //   map); stores to other value types are silently discarded.
+                    //   The accumulator is unchanged (assignment returns its RHS).
+                    Opcode::StaNamedProperty => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("StaNamedProperty", 0));
+                        };
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[1] else {
+                            return Err(err_bad_operand("StaNamedProperty", 1));
+                        };
+                        let prop_name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "StaNamedProperty: property name is not a string".into(),
+                                ));
+                            }
+                        };
+                        let val = frame.accumulator.clone();
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        if let JsValue::PlainObject(ref map) = obj {
+                            map.borrow_mut().insert(prop_name, val);
+                        }
+                        // Accumulator stays unchanged: the assignment's completion
+                        // value is the stored value (already in the accumulator).
+                    }
+
+                    // LdaKeyedProperty [object_reg, feedback_slot]:
+                    //   Load the keyed property from the object in `object_reg`.
+                    //   The key is in the accumulator.
+                    //   Supports PlainObject (string keys), Array (integer keys),
+                    //   and String (character-at-index).  Falls back to
+                    //   `undefined` for other types or missing properties.
+                    Opcode::LdaKeyedProperty => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaKeyedProperty", 0));
+                        };
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        let key = frame.accumulator.clone();
+                        frame.accumulator = keyed_load(&obj, &key)?;
+                    }
+
+                    // StaKeyedProperty [object_reg, key_reg, feedback_slot]:
+                    //   Store the accumulator into the keyed property on the
+                    //   object held in `object_reg`.  The key is in `key_reg`.
+                    //   Supports PlainObject (string keys) and Array (integer
+                    //   indices via PlainObject).  Stores to other value types
+                    //   are silently discarded.
+                    //   The accumulator is unchanged (assignment returns its RHS).
+                    Opcode::StaKeyedProperty => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("StaKeyedProperty", 0));
+                        };
+                        let Operand::Register(key_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("StaKeyedProperty", 1));
+                        };
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        let key = frame.read_reg(key_v)?.clone();
+                        let val = frame.accumulator.clone();
+                        keyed_store(&obj, &key, val)?;
+                        // Accumulator stays unchanged.
+                    }
+
+                    //
+                    // GetIterator [iterable_reg, load_slot, call_slot]:
+                    //   Obtain a sync iterator from the iterable in `iterable_reg`.
+                    //
+                    //   Supported iterables:
+                    //   - JsValue::Array   → NativeIterator over the array elements
+                    //   - JsValue::String  → NativeIterator over Unicode characters
+                    //   - JsValue::Generator → generators are their own iterators
+                    //   - JsValue::Iterator → pass through unchanged
+                    //
+                    //   The result is placed in the accumulator.
+                    Opcode::GetIterator => {
+                        let Operand::Register(iter_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("GetIterator", 0));
+                        };
+                        let iterable = frame.read_reg(iter_v)?.clone();
+                        frame.accumulator = match iterable {
+                            JsValue::Array(items) => {
+                                let items_vec: Vec<JsValue> = (*items).clone();
+                                JsValue::Iterator(NativeIterator::from_items(items_vec))
+                            }
+                            JsValue::String(ref s) => {
+                                JsValue::Iterator(NativeIterator::from_string(s))
+                            }
+                            // Generators and existing iterators pass through unchanged.
+                            JsValue::Generator(_) | JsValue::Iterator(_) => iterable,
+                            // PlainObject with @@iterator → call it to get the iterator.
+                            JsValue::PlainObject(ref map)
+                                if map.borrow().contains_key("@@iterator") =>
+                            {
+                                let iter_fn = map.borrow().get("@@iterator").cloned();
+                                if let Some(JsValue::NativeFunction(f)) = iter_fn {
+                                    f(vec![])?
+                                } else {
+                                    return Err(StatorError::TypeError(
+                                        "GetIterator: @@iterator is not a function".into(),
+                                    ));
+                                }
+                            }
+                            // PlainObject with a "length" property → array-like.
+                            JsValue::PlainObject(ref map)
+                                if map.borrow().contains_key("length") =>
+                            {
+                                let items = plain_object_to_array_items(map);
+                                JsValue::Iterator(NativeIterator::from_items(items))
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "GetIterator: value is not iterable (got {other:?})"
+                                )));
+                            }
+                        };
+                    }
+
+                    // GetAsyncIterator [iterable_reg, load_slot, call_slot]:
+                    //   Async variant — behaves identically to GetIterator for all
+                    //   currently-supported iterable types.
+                    Opcode::GetAsyncIterator => {
+                        let Operand::Register(iter_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("GetAsyncIterator", 0));
+                        };
+                        let iterable = frame.read_reg(iter_v)?.clone();
+                        frame.accumulator = match iterable {
+                            JsValue::Array(items) => {
+                                let items_vec: Vec<JsValue> = (*items).clone();
+                                JsValue::Iterator(NativeIterator::from_items(items_vec))
+                            }
+                            JsValue::String(ref s) => {
+                                JsValue::Iterator(NativeIterator::from_string(s))
+                            }
+                            JsValue::Generator(_) | JsValue::Iterator(_) => iterable,
+                            // PlainObject with @@iterator → call it to get the iterator.
+                            JsValue::PlainObject(ref map)
+                                if map.borrow().contains_key("@@iterator") =>
+                            {
+                                let iter_fn = map.borrow().get("@@iterator").cloned();
+                                if let Some(JsValue::NativeFunction(f)) = iter_fn {
+                                    f(vec![])?
+                                } else {
+                                    return Err(StatorError::TypeError(
+                                        "GetAsyncIterator: @@iterator is not a function".into(),
+                                    ));
+                                }
+                            }
+                            JsValue::PlainObject(ref map)
+                                if map.borrow().contains_key("length") =>
+                            {
+                                let items = plain_object_to_array_items(map);
+                                JsValue::Iterator(NativeIterator::from_items(items))
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "GetAsyncIterator: value is not iterable (got {other:?})"
+                                )));
+                            }
+                        };
+                    }
+
+                    // IteratorNext [iterator_reg, value_out_reg]:
+                    //   Advance the iterator stored in `iterator_reg` by one step.
+                    //
+                    //   Semantics:
+                    //   - `value_out_reg ← next value` (or `undefined` when done)
+                    //   - `acc ← done` (a `JsValue::Boolean`)
+                    //
+                    //   Supported iterator types:
+                    //   - JsValue::Iterator (NativeIterator)
+                    //   - JsValue::Generator (runs one generator step via
+                    //     `run_generator_step`)
+                    Opcode::IteratorNext => {
+                        let Operand::Register(iter_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("IteratorNext", 0));
+                        };
+                        let Operand::Register(value_out_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("IteratorNext", 1));
+                        };
+                        let iter = frame.read_reg(iter_v)?.clone();
+                        let (value, done) = match iter {
+                            JsValue::Iterator(ni) => match ni.borrow_mut().next_item() {
+                                Some(v) => (v, false),
+                                None => (JsValue::Undefined, true),
+                            },
+                            JsValue::Generator(ref gs) => {
+                                match Interpreter::run_generator_step(gs, JsValue::Undefined)? {
+                                    GeneratorStep::Yield(v) => (v, false),
+                                    GeneratorStep::Return(v) => (v, true),
+                                }
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "IteratorNext: value is not an iterator (got {other:?})"
+                                )));
+                            }
+                        };
+                        frame.write_reg(value_out_v, value)?;
+                        frame.accumulator = JsValue::Boolean(done);
+                    }
+
+                    // ── Generators / Async ─────────────────────────────────────
+                    //
+                    // SuspendGenerator [gen, regs_start, regs_count, suspend_id]:
+                    //   Yield a value from a generator function.
+                    //
+                    //   The yield value is whatever is currently in the accumulator.
+                    //   When a generator_state is attached to the frame, the full
+                    //   register file is saved back into it and the resume PC is
+                    //   recorded so execution can continue from after this instruction
+                    //   on the next call to `run_generator_step`.  The yielded value is
+                    //   signalled to `run_generator_step` via `frame.suspend_result`,
+                    //   then the interpreter loop exits early.
+                    Opcode::SuspendGenerator => {
+                        let yield_val = frame.accumulator.clone();
+
+                        // Save state into the attached GeneratorState (if any).
+                        if let Some(gs_rc) = frame.generator_state.as_ref() {
+                            let mut gs = gs_rc.borrow_mut();
+                            // Save the full register file so that ResumeGenerator
+                            // can restore it on the next step.
+                            gs.registers.clone_from(&frame.registers);
+                            // frame.pc was already advanced past this instruction.
+                            gs.resume_pc = frame.pc;
+                            gs.status = GeneratorStatus::SuspendedAtYield;
+                        }
+
+                        frame.suspend_result = Some(yield_val.clone());
+                        return Ok(yield_val);
+                    }
+
+                    // ResumeGenerator [gen, regs_start, regs_count]:
+                    //   Restore the register file from the generator state saved by a
+                    //   prior SuspendGenerator.  The accumulator is left untouched: it
+                    //   already holds the value sent by the caller of `.next(value)`.
+                    Opcode::ResumeGenerator => {
+                        if let Some(gs_rc) = frame.generator_state.as_ref() {
+                            let mut gs = gs_rc.borrow_mut();
+                            // Restore the saved registers into the frame.
+                            // The saved register file has the same length as the frame
+                            // (set by SuspendGenerator from frame.registers.clone()), so
+                            // the min() only protects against a fresh generator where
+                            // gs.registers is empty (resume_pc == 0).
+                            let count = gs.registers.len().min(frame.registers.len());
+                            frame.registers[..count].clone_from_slice(&gs.registers[..count]);
+                            gs.status = GeneratorStatus::Executing;
+                        }
+                        // Accumulator keeps the resume value supplied by run_generator_step.
+                    }
+
+                    // GetGeneratorState [gen]:
+                    //   Load the generator's lifecycle state as a Smi into the
+                    //   accumulator.  Encoding: Executing=−2, Completed=−1,
+                    //   SuspendedAtStart=0, SuspendedAtYield=1.
+                    Opcode::GetGeneratorState => {
+                        frame.accumulator = if let Some(gs_rc) = frame.generator_state.as_ref() {
+                            JsValue::Smi(gs_rc.borrow().status.to_smi())
+                        } else {
+                            JsValue::Smi(GeneratorStatus::Completed.to_smi())
+                        };
+                    }
+
+                    // SetGeneratorState [gen]:
+                    //   Write the Smi in the accumulator back to the generator's state.
+                    Opcode::SetGeneratorState => {
+                        if let Some(gs_rc) = frame.generator_state.as_ref()
+                            && let JsValue::Smi(n) = frame.accumulator
+                        {
+                            gs_rc.borrow_mut().status = GeneratorStatus::from_smi(n);
+                        }
+                    }
+
+                    // SwitchOnGeneratorState [gen]:
+                    //   At the beginning of a generator function, dispatch execution to
+                    //   the saved resume point when the generator has been previously
+                    //   suspended.  If the generator is fresh (resume_pc == 0), fall
+                    //   through to the next instruction (start of the function body).
+                    //
+                    //   Note: when called via `run_generator_step`, the frame's PC is
+                    //   already set to `resume_pc`, so this instruction only fires on
+                    //   the first call (when resume_pc == 0) and falls through.  It
+                    //   becomes useful when the generator bytecode is always entered
+                    //   from PC 0 (the V8 pattern).
+                    Opcode::SwitchOnGeneratorState => {
+                        if let Some(gs_rc) = frame.generator_state.as_ref() {
+                            let resume_pc = gs_rc.borrow().resume_pc;
+                            if resume_pc > 0 {
+                                frame.pc = resume_pc;
+                            }
+                        }
+                    }
+
+                    // ── Debugger statement ─────────────────────────────────────
+                    //
+                    // Debugger []:
+                    //   Trigger a debugger breakpoint when a debugger is attached.
+                    //   When no debugger is active, this instruction is a no-op.
+                    //   The program counter has already been advanced past this
+                    //   instruction, so the pause fires *after* the statement.
+                    Opcode::Debugger => {
+                        let stmt_offset = byte_offsets[frame.pc - 1] as u32;
+                        if let Some(pause_err) = ACTIVE_DEBUGGER.with(|d| {
+                            let opt = d.borrow();
+                            opt.as_ref()
+                                .map(|rc| rc.borrow_mut().on_debugger_statement(stmt_offset))
+                        }) {
+                            return Err(pause_err);
+                        }
+                        // No debugger attached: debugger; is a no-op.
+                    }
+
+                    // ── TypeOf ──────────────────────────────────────────────────
+                    //
+                    // TypeOf [slot]:
+                    //   Replace the accumulator with the string result of
+                    //   `typeof acc`, following the ECMAScript specification
+                    //   (notably, `typeof null === "object"`).
+                    Opcode::TypeOf => {
+                        let type_str = match &frame.accumulator {
+                            JsValue::Undefined => "undefined",
+                            JsValue::Null => "object",
+                            JsValue::Boolean(_) => "boolean",
+                            JsValue::Smi(_) | JsValue::HeapNumber(_) => "number",
+                            JsValue::String(_) => "string",
+                            JsValue::Symbol(_) => "symbol",
+                            JsValue::BigInt(_) => "bigint",
+                            JsValue::Function(_) | JsValue::NativeFunction(_) => "function",
+                            JsValue::Object(_)
+                            | JsValue::Array(_)
+                            | JsValue::PlainObject(_)
+                            | JsValue::Error(_) => "object",
+                            JsValue::Generator(_) => "object",
+                            JsValue::Iterator(_) => "object",
+                            JsValue::Promise(_) => "object",
+                            JsValue::Context(_) => "object",
+                        };
+                        frame.accumulator = JsValue::String(type_str.to_owned());
+                    }
+
+                    // ── TestTypeOf ─────────────────────────────────────────────
+                    //
+                    // TestTypeOf [flag]:
+                    //   Tests whether `typeof acc` matches the type encoded in
+                    //   `flag`.  Sets the accumulator to a boolean result.
+                    //   Flag encoding (V8 convention):
+                    //     0 = number, 1 = string, 2 = symbol, 3 = boolean,
+                    //     4 = bigint, 5 = undefined, 6 = function, 7 = object
+                    Opcode::TestTypeOf => {
+                        let Operand::Flag(flag) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestTypeOf", 0));
+                        };
+                        let matches_type = match flag {
+                            0 => matches!(
+                                frame.accumulator,
+                                JsValue::Smi(_) | JsValue::HeapNumber(_)
+                            ),
+                            1 => matches!(frame.accumulator, JsValue::String(_)),
+                            2 => matches!(frame.accumulator, JsValue::Symbol(_)),
+                            3 => matches!(frame.accumulator, JsValue::Boolean(_)),
+                            4 => matches!(frame.accumulator, JsValue::BigInt(_)),
+                            5 => matches!(frame.accumulator, JsValue::Undefined),
+                            6 => matches!(
+                                frame.accumulator,
+                                JsValue::Function(_) | JsValue::NativeFunction(_)
+                            ),
+                            7 => matches!(
+                                frame.accumulator,
+                                JsValue::Null
+                                    | JsValue::Object(_)
+                                    | JsValue::Array(_)
+                                    | JsValue::PlainObject(_)
+                                    | JsValue::Error(_)
+                                    | JsValue::Generator(_)
+                                    | JsValue::Iterator(_)
+                                    | JsValue::Promise(_)
+                            ),
+                            _ => false,
+                        };
+                        frame.accumulator = JsValue::Boolean(matches_type);
+                    }
+
+                    // ── Type coercion ──────────────────────────────────────────
+                    Opcode::ToNumber => {
+                        // operands[0] is a FeedbackSlot, ignored at runtime.
+                        let n = frame.accumulator.to_number()?;
+                        frame.accumulator = number_to_jsvalue(n);
+                    }
+                    Opcode::ToString => {
+                        let s = frame.accumulator.to_js_string()?;
+                        frame.accumulator = JsValue::String(s);
+                    }
+                    Opcode::ToBoolean => {
+                        // operands[0] is a FeedbackSlot, ignored at runtime.
+                        let b = frame.accumulator.to_boolean();
+                        frame.accumulator = JsValue::Boolean(b);
+                    }
+                    Opcode::ToObject => {
+                        // operands[0] is a Register destination.
+                        let Operand::Register(dst) = instr.operands[0] else {
+                            return Err(err_bad_operand("ToObject", 0));
+                        };
+                        match &frame.accumulator {
+                            JsValue::Null | JsValue::Undefined => {
+                                return Err(StatorError::TypeError(
+                                    "Cannot convert undefined or null to object".to_string(),
+                                ));
+                            }
+                            _ => {
+                                // Objects/arrays stay as-is; primitives would need
+                                // wrapper objects (not yet implemented).
+                                let val = frame.accumulator.clone();
+                                frame.write_reg(dst, val)?;
+                            }
+                        }
+                    }
+                    Opcode::ToName => {
+                        // operands[0] is a Register destination.
+                        // Convert accumulator to a property key (string or symbol).
+                        let Operand::Register(dst) = instr.operands[0] else {
+                            return Err(err_bad_operand("ToName", 0));
+                        };
+                        let key = match &frame.accumulator {
+                            JsValue::String(_) | JsValue::Symbol(_) => frame.accumulator.clone(),
+                            other => JsValue::String(other.to_js_string()?),
+                        };
+                        frame.write_reg(dst, key)?;
+                    }
+
+                    // ── Unary arithmetic ──────────────────────────────────────────
+                    Opcode::Negate => {
+                        // operands[0] is a FeedbackSlot, ignored at runtime.
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(n.wrapping_neg());
+                        } else {
+                            let n = frame.accumulator.to_number()?;
+                            frame.accumulator = number_to_jsvalue(-n);
+                        }
+                    }
+                    Opcode::BitwiseNot => {
+                        // operands[0] is a FeedbackSlot, ignored at runtime.
+                        if let JsValue::BigInt(n) = &frame.accumulator {
+                            frame.accumulator = JsValue::BigInt(!n);
+                        } else {
+                            let n = frame.accumulator.to_number()? as i32;
+                            frame.accumulator = JsValue::Smi(!n);
+                        }
+                    }
+
+                    // CreateEmptyObjectLiteral:
+                    //   Create a new empty PlainObject and store it in the accumulator.
+                    Opcode::CreateEmptyObjectLiteral => {
+                        frame.accumulator =
+                            JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
+                    }
+
+                    // CreateEmptyArrayLiteral [feedback_slot]:
+                    //   Create a new empty array-like PlainObject and store it in
+                    //   the accumulator.  The bytecode generator populates the
+                    //   elements afterwards via StaInArrayLiteral.
+                    Opcode::CreateEmptyArrayLiteral => {
+                        // operands[0] is a FeedbackSlot, ignored at runtime.
+                        let mut map = HashMap::new();
+                        map.insert("length".to_string(), JsValue::Smi(0));
+                        frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
+                    }
+
+                    // CreateArrayLiteral [elements_const_pool_idx, feedback_slot, flags]:
+                    //   Create an array from a constant-pool boilerplate.  For now
+                    //   this simply creates an empty array-like PlainObject (the
+                    //   bytecode generator currently uses CreateEmptyArrayLiteral
+                    //   + StaInArrayLiteral instead).
+                    Opcode::CreateArrayLiteral => {
+                        // operands: [ConstantPoolIdx, FeedbackSlot, Flag]
+                        let mut map = HashMap::new();
+                        map.insert("length".to_string(), JsValue::Smi(0));
+                        frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
+                    }
+
+                    // CreateArrayFromIterable:
+                    //   Create an array from an iterable (used for spread to
+                    //   array).  Consumes the iterator in the accumulator and
+                    //   collects all yielded values into a new array.
+                    Opcode::CreateArrayFromIterable => {
+                        let iterable = frame.accumulator.clone();
+                        let items: Vec<JsValue> = match &iterable {
+                            JsValue::Array(arr) => (**arr).clone(),
+                            JsValue::Iterator(iter) => {
+                                let mut out = Vec::new();
+                                loop {
+                                    let mut it = iter.borrow_mut();
+                                    match it.next_item() {
+                                        Some(v) => out.push(v),
+                                        None => break,
+                                    }
+                                }
+                                out
+                            }
+                            _ => vec![],
+                        };
+                        let mut map = HashMap::new();
+                        for (i, v) in items.iter().enumerate() {
+                            map.insert(i.to_string(), v.clone());
+                        }
+                        map.insert("length".to_string(), JsValue::Smi(items.len() as i32));
+                        frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
+                    }
+
+                    // CreateObjectLiteral [boilerplate_const_pool_idx, feedback_slot, flags]:
+                    //   Create an object from a constant-pool boilerplate.  For now
+                    //   this simply creates an empty PlainObject (the bytecode
+                    //   generator currently uses CreateEmptyObjectLiteral +
+                    //   DefineNamedOwnProperty instead).
+                    Opcode::CreateObjectLiteral => {
+                        // operands: [ConstantPoolIdx, FeedbackSlot, Flag]
+                        frame.accumulator =
+                            JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
+                    }
+
+                    // CreateRegExpLiteral [pattern_const_pool_idx, feedback_slot, flags]:
+                    //   Create a RegExp object from the pattern string in the
+                    //   constant pool.  Represented as a PlainObject with `source`
+                    //   and `flags` properties so that JS code can inspect them.
+                    Opcode::CreateRegExpLiteral => {
+                        let Operand::ConstantPoolIdx(pattern_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("CreateRegExpLiteral", 0));
+                        };
+                        // operands[1] = FeedbackSlot (ignored)
+                        let Operand::Flag(flags_val) = instr.operands[2] else {
+                            return Err(err_bad_operand("CreateRegExpLiteral", 2));
+                        };
+                        let pattern = match frame.bytecode_array.get_constant(pattern_idx) {
+                            Some(ConstantPoolEntry::String(s)) => decode_string_constant(s),
+                            _ => String::new(),
+                        };
+                        // Decode flag bits back to a flag string.
+                        let mut flags_str = String::new();
+                        if flags_val & 0x01 != 0 {
+                            flags_str.push('g');
+                        }
+                        if flags_val & 0x02 != 0 {
+                            flags_str.push('i');
+                        }
+                        if flags_val & 0x04 != 0 {
+                            flags_str.push('m');
+                        }
+                        if flags_val & 0x08 != 0 {
+                            flags_str.push('s');
+                        }
+                        if flags_val & 0x10 != 0 {
+                            flags_str.push('u');
+                        }
+                        if flags_val & 0x20 != 0 {
+                            flags_str.push('y');
+                        }
+                        let mut map = HashMap::new();
+                        map.insert("source".to_string(), JsValue::String(pattern.clone()));
+                        map.insert("flags".to_string(), JsValue::String(flags_str.clone()));
+                        // toString() representation: /pattern/flags
+                        map.insert(
+                            "toString".to_string(),
+                            JsValue::String(format!("/{pattern}/{flags_str}")),
+                        );
+                        frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
+                    }
+
+                    // StaInArrayLiteral [array_reg, index_reg, feedback_slot]:
+                    //   Store the accumulator into the array at the given index.
+                    //   The array is a PlainObject with string-keyed numeric
+                    //   indices and a `"length"` property.
+                    Opcode::StaInArrayLiteral => {
+                        let Operand::Register(arr_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("StaInArrayLiteral", 0));
+                        };
+                        let Operand::Register(idx_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("StaInArrayLiteral", 1));
+                        };
+                        // operands[2] is a FeedbackSlot, ignored at runtime.
+                        let arr = frame.read_reg(arr_v)?.clone();
+                        let key = frame.read_reg(idx_v)?.clone();
+                        let val = frame.accumulator.clone();
+                        if let JsValue::PlainObject(ref map) = arr {
+                            let idx_str = to_property_key(&key)?;
+                            map.borrow_mut().insert(idx_str, val);
+                            // Update length: max(current_length, index + 1).
+                            if let Some(idx) = to_array_index(&key) {
+                                let new_len = (idx + 1) as i32;
+                                let cur_len = match map.borrow().get("length") {
+                                    Some(JsValue::Smi(n)) => *n,
+                                    _ => 0,
+                                };
+                                if new_len > cur_len {
+                                    map.borrow_mut()
+                                        .insert("length".to_string(), JsValue::Smi(new_len));
+                                }
+                            }
+                        }
+                        // Accumulator stays unchanged.
+                    }
+
+                    // DefineNamedOwnProperty [object_reg, name_const_pool_idx, feedback_slot]:
+                    //   Define a named own property on the object held in
+                    //   `object_reg`.  Semantically identical to StaNamedProperty
+                    //   for PlainObjects.
+                    Opcode::DefineNamedOwnProperty => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("DefineNamedOwnProperty", 0));
+                        };
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[1] else {
+                            return Err(err_bad_operand("DefineNamedOwnProperty", 1));
+                        };
+                        // operands[2] is a FeedbackSlot, ignored at runtime.
+                        let prop_name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "DefineNamedOwnProperty: property name is not a string".into(),
+                                ));
+                            }
+                        };
+                        let val = frame.accumulator.clone();
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        if let JsValue::PlainObject(ref map) = obj {
+                            map.borrow_mut().insert(prop_name, val);
+                        }
+                        // Accumulator stays unchanged.
+                    }
+
+                    // DefineKeyedOwnProperty [object_reg, key_reg, flags, feedback_slot]:
+                    //   Define a keyed own property on the object held in
+                    //   `object_reg`.  The key is in `key_reg`.  Semantically
+                    //   identical to StaKeyedProperty for PlainObjects.
+                    Opcode::DefineKeyedOwnProperty => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("DefineKeyedOwnProperty", 0));
+                        };
+                        let Operand::Register(key_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("DefineKeyedOwnProperty", 1));
+                        };
+                        // operands[2] = Flag (ignored), operands[3] = FeedbackSlot (ignored).
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        let key = frame.read_reg(key_v)?.clone();
+                        let val = frame.accumulator.clone();
+                        if let JsValue::PlainObject(ref map) = obj {
+                            let prop_name = to_property_key(&key)?;
+                            map.borrow_mut().insert(prop_name, val);
+                        }
+                        // Accumulator stays unchanged.
+                    }
+
+                    // DefineKeyedOwnPropertyInLiteral [object_reg, key_reg, flags, feedback_slot]:
+                    //   Same as DefineKeyedOwnProperty — used in object literal
+                    //   context.
+                    Opcode::DefineKeyedOwnPropertyInLiteral => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("DefineKeyedOwnPropertyInLiteral", 0));
+                        };
+                        let Operand::Register(key_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("DefineKeyedOwnPropertyInLiteral", 1));
+                        };
+                        // operands[2] = Flag (ignored), operands[3] = FeedbackSlot (ignored).
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        let key = frame.read_reg(key_v)?.clone();
+                        let val = frame.accumulator.clone();
+                        if let JsValue::PlainObject(ref map) = obj {
+                            let prop_name = to_property_key(&key)?;
+                            map.borrow_mut().insert(prop_name, val);
+                        }
+                        // Accumulator stays unchanged.
+                    }
+
+                    // ── TestInstanceOf ──────────────────────────────────────────
+                    //
+                    // TestInstanceOf [constructor_reg, feedback_slot]:
+                    //   Tests whether `acc` is an instance of the constructor held
+                    //   in `constructor_reg`.  Sets the accumulator to a boolean.
+                    //   Simplified: always `false` unless we can walk the prototype
+                    //   chain (PlainObject with a `__proto__` key that matches the
+                    //   constructor's `"prototype"` property).
+                    Opcode::TestInstanceOf => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestInstanceOf", 0));
+                        };
+                        let constructor = frame.read_reg(v)?.clone();
+
+                        // Obtain the constructor's "prototype" property.
+                        let ctor_proto = match &constructor {
+                            JsValue::PlainObject(map) => map.borrow().get("prototype").cloned(),
+                            _ => None,
+                        };
+
+                        let result = if let Some(proto_val) = ctor_proto {
+                            // Walk the __proto__ chain of the accumulator object.
+                            let mut current = frame.accumulator.clone();
+                            let mut found = false;
+                            for _ in 0..256 {
+                                // Check if current is the same object as proto_val
+                                match &current {
+                                    JsValue::PlainObject(map) => {
+                                        // If this object *is* the prototype, match.
+                                        if let JsValue::PlainObject(p) = &proto_val
+                                            && Rc::ptr_eq(map, p)
+                                        {
+                                            found = true;
+                                            break;
+                                        }
+                                        // Walk up via __proto__
+                                        let next = map.borrow().get("__proto__").cloned();
+                                        match next {
+                                            Some(v) => current = v,
+                                            None => break,
+                                        }
+                                    }
+                                    _ => break,
+                                }
+                            }
+                            found
+                        } else {
+                            false
+                        };
+
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+
+                    // ── TestIn ─────────────────────────────────────────────────
+                    //
+                    // TestIn [object_reg, feedback_slot]:
+                    //   Tests whether the property key held in the accumulator
+                    //   exists in the object held in `object_reg`.  Sets the
+                    //   accumulator to a boolean result.
+                    Opcode::TestIn => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestIn", 0));
+                        };
+                        let object = frame.read_reg(v)?.clone();
+                        let key = &frame.accumulator;
+
+                        let result = match &object {
+                            JsValue::PlainObject(_) => {
+                                let prop = to_property_key(key)?;
+                                // Walk the prototype chain for `in` operator.
+                                !matches!(proto_lookup(&object, &prop), JsValue::Undefined)
+                            }
+                            JsValue::Array(items) => {
+                                // "length" is always present on arrays.
+                                if let JsValue::String(s) = key
+                                    && s == "length"
+                                {
+                                    true
+                                } else if let Some(idx) = to_array_index(key) {
+                                    idx < items.len()
+                                } else {
+                                    false
+                                }
+                            }
+                            _ => false,
+                        };
+
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+
+                    // ── For-in ─────────────────────────────────────────────────
+                    //
+                    // ForInEnumerate [obj_reg]:
+                    //   Collect the enumerable string-keyed own properties of the
+                    //   object stored in `obj_reg` into a JsValue::Array and set
+                    //   the accumulator to that array.  If the value is null or
+                    //   undefined the result is an empty array.
+                    Opcode::ForInEnumerate => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("ForInEnumerate", 0));
+                        };
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        let keys: Vec<JsValue> = match &obj {
+                            JsValue::PlainObject(map) => map
+                                .borrow()
+                                .keys()
+                                .map(|k| JsValue::String(k.clone()))
+                                .collect(),
+                            JsValue::Array(items) => {
+                                let mut ks: Vec<JsValue> = (0..items.len())
+                                    .map(|i| JsValue::String(i.to_string()))
+                                    .collect();
+                                ks.push(JsValue::String("length".to_string()));
+                                ks
+                            }
+                            JsValue::Null | JsValue::Undefined => vec![],
+                            _ => vec![],
+                        };
+                        frame.accumulator = JsValue::Array(Rc::new(keys));
+                    }
+
+                    // ForInPrepare [cache_array_reg, feedback_slot]:
+                    //   Read the length of the key array stored in
+                    //   `cache_array_reg` and set the accumulator to that length
+                    //   as an Smi.
+                    Opcode::ForInPrepare => {
+                        let Operand::Register(keys_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("ForInPrepare", 0));
+                        };
+                        // operands[1] is a FeedbackSlot, ignored at runtime.
+                        let keys = frame.read_reg(keys_v)?.clone();
+                        let len = match &keys {
+                            JsValue::Array(items) => items.len() as i32,
+                            _ => 0,
+                        };
+                        frame.accumulator = JsValue::Smi(len);
+                    }
+
+                    // ForInNext [receiver_reg, index_reg, cache_array_reg,
+                    //            feedback_slot]:
+                    //   Read the key at position `index` from the enumeration
+                    //   cache array and set the accumulator to that key.
+                    Opcode::ForInNext => {
+                        let Operand::Register(_receiver_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("ForInNext", 0));
+                        };
+                        let Operand::Register(idx_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("ForInNext", 1));
+                        };
+                        let Operand::Register(keys_v) = instr.operands[2] else {
+                            return Err(err_bad_operand("ForInNext", 2));
+                        };
+                        // operands[3] is a FeedbackSlot, ignored at runtime.
+                        let idx = match frame.read_reg(idx_v)? {
+                            JsValue::Smi(n) => *n as usize,
+                            _ => 0,
+                        };
+                        let keys = frame.read_reg(keys_v)?.clone();
+                        let key = match &keys {
+                            JsValue::Array(items) => {
+                                items.get(idx).cloned().unwrap_or(JsValue::Undefined)
+                            }
+                            _ => JsValue::Undefined,
+                        };
+                        frame.accumulator = key;
+                    }
+
+                    // ForInStep [index_reg]:
+                    //   Read the current index from `index_reg`, increment by 1,
+                    //   and set the accumulator to the new value.
+                    Opcode::ForInStep => {
+                        let Operand::Register(idx_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("ForInStep", 0));
+                        };
+                        let idx = match frame.read_reg(idx_v)? {
+                            JsValue::Smi(n) => *n,
+                            _ => 0,
+                        };
+                        frame.accumulator = JsValue::Smi(idx + 1);
+                    }
+
+                    // JumpIfForInDone [offset, index_reg, cache_length_reg]:
+                    //   Compare the index in `index_reg` to the length in
+                    //   `cache_length_reg`.  If index >= length, jump by offset.
+                    Opcode::JumpIfForInDone => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfForInDone", 0));
+                        };
+                        let Operand::Register(idx_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("JumpIfForInDone", 1));
+                        };
+                        let Operand::Register(len_v) = instr.operands[2] else {
+                            return Err(err_bad_operand("JumpIfForInDone", 2));
+                        };
+                        let idx = match frame.read_reg(idx_v)? {
+                            JsValue::Smi(n) => *n,
+                            _ => 0,
+                        };
+                        let len = match frame.read_reg(len_v)? {
+                            JsValue::Smi(n) => *n,
+                            _ => 0,
+                        };
+                        if idx >= len {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+
+                    // ── Delete property ───────────────────────────────────────
+
+                    // DeletePropertySloppy [object_reg]:
+                    //   Delete the property named by the accumulator from the
+                    //   object in `object_reg`.  Non-configurable properties
+                    //   silently fail; the accumulator receives `true`/`false`.
+                    Opcode::DeletePropertySloppy => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("DeletePropertySloppy", 0));
+                        };
+                        let key = to_property_key(&frame.accumulator)?;
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        let removed = if let JsValue::PlainObject(ref map) = obj {
+                            map.borrow_mut().remove(&key).is_some()
+                        } else {
+                            false
+                        };
+                        frame.accumulator = JsValue::Boolean(removed);
+                    }
+
+                    // DeletePropertyStrict [object_reg]:
+                    //   Like DeletePropertySloppy but throws TypeError when the
+                    //   property exists and is non-configurable.  For our
+                    //   simplified PlainObject model every property is
+                    //   configurable, so this behaves the same as sloppy mode.
+                    Opcode::DeletePropertyStrict => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("DeletePropertyStrict", 0));
+                        };
+                        let key = to_property_key(&frame.accumulator)?;
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        if let JsValue::PlainObject(ref map) = obj {
+                            map.borrow_mut().remove(&key);
+                        }
+                        frame.accumulator = JsValue::Boolean(true);
+                    }
+
+                    // ── Arguments / rest parameter ───────────────────────────────
+
+                    // CreateRestParameter []:
+                    //   Collect all arguments beyond the formal parameter count
+                    //   into a JsValue::Array.
+                    Opcode::CreateRestParameter => {
+                        let param_count = frame.bytecode_array.parameter_count() as usize;
+                        let rest: Vec<JsValue> = if frame.registers.len() > param_count {
+                            frame.registers[param_count..].to_vec()
+                        } else {
+                            vec![]
+                        };
+                        frame.accumulator = JsValue::Array(Rc::new(rest));
+                    }
+
+                    // CreateMappedArguments []:
+                    //   Create a sloppy-mode `arguments` object.  Implemented as
+                    //   a PlainObject with indexed string keys and a `length`
+                    //   property.
+                    Opcode::CreateMappedArguments => {
+                        let param_count = frame.bytecode_array.parameter_count() as usize;
+                        let args: Vec<JsValue> =
+                            frame.registers.get(..param_count).unwrap_or(&[]).to_vec();
+                        let map: HashMap<String, JsValue> = args
+                            .iter()
+                            .enumerate()
+                            .map(|(i, v)| (i.to_string(), v.clone()))
+                            .chain(std::iter::once((
+                                "length".to_string(),
+                                JsValue::Smi(args.len() as i32),
+                            )))
+                            .collect();
+                        frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
+                    }
+
+                    // CreateUnmappedArguments []:
+                    //   Create a strict-mode `arguments` object (snapshot copy).
+                    //   Same shape as mapped but values are not aliased.
+                    Opcode::CreateUnmappedArguments => {
+                        let param_count = frame.bytecode_array.parameter_count() as usize;
+                        let args: Vec<JsValue> =
+                            frame.registers.get(..param_count).unwrap_or(&[]).to_vec();
+                        let map: HashMap<String, JsValue> = args
+                            .iter()
+                            .enumerate()
+                            .map(|(i, v)| (i.to_string(), v.clone()))
+                            .chain(std::iter::once((
+                                "length".to_string(),
+                                JsValue::Smi(args.len() as i32),
+                            )))
+                            .collect();
+                        frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
+                    }
+
+                    // ── Throw-if-hole opcodes (TDZ checks) ──────────────────────
+
+                    // ThrowReferenceErrorIfHole [name_idx]:
+                    //   If the accumulator is Undefined (representing a TDZ hole),
+                    //   throw a ReferenceError with the variable name from the
+                    //   constant pool.
+                    Opcode::ThrowReferenceErrorIfHole => {
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("ThrowReferenceErrorIfHole", 0));
+                        };
+                        if frame.accumulator == JsValue::Undefined {
+                            let name = match frame.bytecode_array.get_constant(name_idx) {
+                                Some(ConstantPoolEntry::String(s)) => s.clone(),
+                                _ => "<unknown>".to_string(),
+                            };
+                            return Err(StatorError::ReferenceError(format!(
+                                "Cannot access '{name}' before initialization"
+                            )));
+                        }
+                    }
+
+                    // ThrowSuperNotCalledIfHole []:
+                    //   If the accumulator is Undefined (hole), throw
+                    //   ReferenceError because super() was never called.
+                    Opcode::ThrowSuperNotCalledIfHole => {
+                        if frame.accumulator == JsValue::Undefined {
+                            return Err(StatorError::ReferenceError(
+                                "Must call super constructor in derived class \
+                             before accessing 'this' or returning from \
+                             derived constructor"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+
+                    // ThrowSuperAlreadyCalledIfNotHole []:
+                    //   If the accumulator is NOT Undefined (not a hole), throw
+                    //   ReferenceError because super() was already called.
+                    Opcode::ThrowSuperAlreadyCalledIfNotHole => {
+                        if frame.accumulator != JsValue::Undefined {
+                            return Err(StatorError::ReferenceError(
+                                "Super constructor may only be called once".to_string(),
+                            ));
+                        }
+                    }
+
+                    // ── CallProperty variants ────────────────────────────────────
+
+                    // CallProperty0 [callee_reg, receiver_reg, feedback]:
+                    //   Call `callee` with `receiver` as `this` and zero
+                    //   arguments.
+                    Opcode::CallProperty0 => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallProperty0", 0));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
+                        dispatch_call(frame, &callee, vec![])?;
+                    }
+
+                    // CallProperty1 [callee_reg, receiver_reg, arg0_reg, feedback]:
+                    //   Call `callee` with `receiver` as `this` and one argument.
+                    Opcode::CallProperty1 => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallProperty1", 0));
+                        };
+                        let Operand::Register(arg0_v) = instr.operands[2] else {
+                            return Err(err_bad_operand("CallProperty1", 2));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
+                        let arg0 = frame.read_reg(arg0_v)?.clone();
+                        dispatch_call(frame, &callee, vec![arg0])?;
+                    }
+
+                    // CallProperty2 [callee_reg, receiver_reg, arg0, arg1,
+                    //                 feedback]:
+                    //   Call `callee` with `receiver` as `this` and two arguments.
+                    Opcode::CallProperty2 => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallProperty2", 0));
+                        };
+                        let Operand::Register(arg0_v) = instr.operands[2] else {
+                            return Err(err_bad_operand("CallProperty2", 2));
+                        };
+                        let Operand::Register(arg1_v) = instr.operands[3] else {
+                            return Err(err_bad_operand("CallProperty2", 3));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
+                        let arg0 = frame.read_reg(arg0_v)?.clone();
+                        let arg1 = frame.read_reg(arg1_v)?.clone();
+                        dispatch_call(frame, &callee, vec![arg0, arg1])?;
+                    }
+
+                    // ── CallRuntime ──────────────────────────────────────────────
+
+                    // CallRuntime [runtime_id, args_start, arg_count]:
+                    //   Dispatch to an internal runtime function.  Most runtime
+                    //   functions are optimisation hints that are not
+                    //   correctness-critical, so unrecognised IDs are no-ops.
+                    Opcode::CallRuntime => {
+                        let Operand::RuntimeId(runtime_id) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallRuntime", 0));
+                        };
+                        let Operand::Register(args_start_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("CallRuntime", 1));
+                        };
+                        let Operand::RegisterCount(arg_count) = instr.operands[2] else {
+                            return Err(err_bad_operand("CallRuntime", 2));
+                        };
+
+                        if runtime_id == crate::bytecode::bytecode_generator::RUNTIME_DYNAMIC_IMPORT
+                        {
+                            use crate::builtins::promise::{MicrotaskQueue, promise_resolve};
+
+                            let args = collect_args(frame, args_start_v, arg_count)?;
+                            let specifier = args.first().cloned().unwrap_or(JsValue::Undefined);
+
+                            // Build a namespace object with a default export
+                            // equal to the specifier string (stub for now — a
+                            // full implementation would resolve a module).
+                            let ns = HashMap::new();
+                            let ns_val = JsValue::PlainObject(Rc::new(RefCell::new(ns)));
+
+                            let queue = MicrotaskQueue::new();
+                            let p = promise_resolve(ns_val, &queue);
+                            queue.drain();
+                            frame.accumulator = JsValue::Promise(p);
+
+                            let _ = specifier; // consumed for future use
+                        }
+                        // Unrecognised runtime IDs are no-ops.
+                    }
+
+                    // ── Named own property / lookup slot ─────────────────────────
+
+                    // StaNamedOwnProperty [object_reg, name_idx, feedback]:
+                    //   Define an own property on `object_reg` (like
+                    //   Object.defineProperty).  For the current PlainObject
+                    //   model this is identical to StaNamedProperty.
+                    Opcode::StaNamedOwnProperty => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("StaNamedOwnProperty", 0));
+                        };
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[1] else {
+                            return Err(err_bad_operand("StaNamedOwnProperty", 1));
+                        };
+                        let prop_name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "StaNamedOwnProperty: property name is \
+                                     not a string"
+                                        .into(),
+                                ));
+                            }
+                        };
+                        let val = frame.accumulator.clone();
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        if let JsValue::PlainObject(ref map) = obj {
+                            map.borrow_mut().insert(prop_name, val);
+                        }
+                    }
+
+                    // StaLookupSlot [name_idx, flags]:
+                    //   Store the accumulator to a named variable by walking the
+                    //   scope chain.  Simplified: stores directly into
+                    //   `global_env`.
+                    Opcode::StaLookupSlot => {
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("StaLookupSlot", 0));
+                        };
+                        let name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "StaLookupSlot: slot name is not a string".into(),
+                                ));
+                            }
+                        };
+                        let val = frame.accumulator.clone();
+                        frame.global_env.borrow_mut().insert(name, val);
+                    }
+
+                    // LdaLookupSlot [name_idx]:
+                    //   Dynamic lookup of a variable name in the scope chain.
+                    //   Simplified: looks up in `global_env`, throws
+                    //   ReferenceError if not found.
+                    Opcode::LdaLookupSlot => {
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaLookupSlot", 0));
+                        };
+                        let name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "LdaLookupSlot: slot name is not a string".into(),
+                                ));
+                            }
+                        };
+                        frame.accumulator = match frame.global_env.borrow().get(&name) {
+                            Some(v) => v.clone(),
+                            None => {
+                                return Err(StatorError::ReferenceError(format!(
+                                    "{name} is not defined"
+                                )));
+                            }
+                        };
+                    }
+
+                    // LdaLookupSlotInsideTypeof [name_idx]:
+                    //   Same as LdaLookupSlot but returns undefined instead of
+                    //   throwing ReferenceError (used inside `typeof`).
+                    Opcode::LdaLookupSlotInsideTypeof => {
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaLookupSlotInsideTypeof", 0));
+                        };
+                        let name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "LdaLookupSlotInsideTypeof: slot name is not a string".into(),
+                                ));
+                            }
+                        };
+                        frame.accumulator = frame
+                            .global_env
+                            .borrow()
+                            .get(&name)
+                            .cloned()
+                            .unwrap_or(JsValue::Undefined);
+                    }
+
+                    // LdaLookupContextSlot [name_idx, slot_idx, depth]:
+                    //   Dynamic lookup resolving to a context slot.
+                    //   Simplified: falls back to `global_env`.
+                    Opcode::LdaLookupContextSlot => {
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaLookupContextSlot", 0));
+                        };
+                        let name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "LdaLookupContextSlot: slot name is not a string".into(),
+                                ));
+                            }
+                        };
+                        frame.accumulator = match frame.global_env.borrow().get(&name) {
+                            Some(v) => v.clone(),
+                            None => {
+                                return Err(StatorError::ReferenceError(format!(
+                                    "{name} is not defined"
+                                )));
+                            }
+                        };
+                    }
+
+                    // LdaLookupContextSlotInsideTypeof [name_idx, slot_idx, depth]:
+                    //   Same as LdaLookupContextSlot but returns undefined instead
+                    //   of throwing (used inside `typeof`).
+                    Opcode::LdaLookupContextSlotInsideTypeof => {
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaLookupContextSlotInsideTypeof", 0));
+                        };
+                        let name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "LdaLookupContextSlotInsideTypeof: slot name is not a string"
+                                        .into(),
+                                ));
+                            }
+                        };
+                        frame.accumulator = frame
+                            .global_env
+                            .borrow()
+                            .get(&name)
+                            .cloned()
+                            .unwrap_or(JsValue::Undefined);
+                    }
+
+                    // LdaLookupGlobalSlot [name_idx, slot, depth]:
+                    //   Dynamic lookup resolving to a global slot.
+                    //   Simplified: looks up in `global_env`, throws
+                    //   ReferenceError if not found.
+                    Opcode::LdaLookupGlobalSlot => {
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaLookupGlobalSlot", 0));
+                        };
+                        let name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "LdaLookupGlobalSlot: slot name is not a string".into(),
+                                ));
+                            }
+                        };
+                        frame.accumulator = match frame.global_env.borrow().get(&name) {
+                            Some(v) => v.clone(),
+                            None => {
+                                return Err(StatorError::ReferenceError(format!(
+                                    "{name} is not defined"
+                                )));
+                            }
+                        };
+                    }
+
+                    // LdaLookupGlobalSlotInsideTypeof [name_idx, slot, depth]:
+                    //   Same as LdaLookupGlobalSlot but returns undefined instead
+                    //   of throwing (used inside `typeof`).
+                    Opcode::LdaLookupGlobalSlotInsideTypeof => {
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaLookupGlobalSlotInsideTypeof", 0));
+                        };
+                        let name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "LdaLookupGlobalSlotInsideTypeof: slot name is not a string"
+                                        .into(),
+                                ));
+                            }
+                        };
+                        frame.accumulator = frame
+                            .global_env
+                            .borrow()
+                            .get(&name)
+                            .cloned()
+                            .unwrap_or(JsValue::Undefined);
+                    }
+
+                    // LdaNamedPropertyFromSuper [obj_reg, name_idx, feedback_slot]:
+                    //   Load a named property from the super object.  The
+                    //   accumulator holds the home object; `obj_reg` holds the
+                    //   receiver.  Simplified: delegates to `proto_lookup` on the
+                    //   receiver.
+                    Opcode::LdaNamedPropertyFromSuper => {
+                        let Operand::Register(obj_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("LdaNamedPropertyFromSuper", 0));
+                        };
+                        let Operand::ConstantPoolIdx(name_idx) = instr.operands[1] else {
+                            return Err(err_bad_operand("LdaNamedPropertyFromSuper", 1));
+                        };
+                        let prop_name = match frame.bytecode_array.get_constant(name_idx) {
+                            Some(ConstantPoolEntry::String(s)) => s.clone(),
+                            _ => {
+                                return Err(StatorError::Internal(
+                                    "LdaNamedPropertyFromSuper: property name is not a string"
+                                        .into(),
+                                ));
+                            }
+                        };
+                        let obj = frame.read_reg(obj_v)?.clone();
+                        frame.accumulator = proto_lookup(&obj, &prop_name);
+                    }
+
+                    // GetTemplateObject [template_idx, feedback_slot]:
+                    //   Create an array of template strings, freeze it, and cache
+                    //   by the current bytecode offset.
+                    Opcode::GetTemplateObject => {
+                        let Operand::ConstantPoolIdx(tpl_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("GetTemplateObject", 0));
+                        };
+                        let cache_key = byte_offsets[frame.pc - 1] as u32;
+                        if let Some(cached) = frame.template_cache.get(&cache_key) {
+                            frame.accumulator = cached.clone();
+                        } else {
+                            let entry =
+                            frame.bytecode_array.get_constant(tpl_idx).ok_or_else(|| {
+                                StatorError::Internal(format!(
+                                    "GetTemplateObject: constant pool index {tpl_idx} out of bounds"
+                                ))
+                            })?;
+                            let tpl_val = constant_to_value(entry);
+                            frame.template_cache.insert(cache_key, tpl_val.clone());
+                            frame.accumulator = tpl_val;
+                        }
+                    }
+
+                    // SetPendingMessage:
+                    //   Swap the accumulator with the pending-exception message
+                    //   slot.  Used by `finally` blocks to save/restore the
+                    //   pending exception.
+                    Opcode::SetPendingMessage => {
+                        std::mem::swap(&mut frame.accumulator, &mut frame.pending_message);
+                    }
+
+                    // TestReferenceEqual [reg]:
+                    //   Strict reference identity check (===).
+                    Opcode::TestReferenceEqual => {
+                        let Operand::Register(v) = instr.operands[0] else {
+                            return Err(err_bad_operand("TestReferenceEqual", 0));
+                        };
+                        let rhs = frame.read_reg(v)?.clone();
+                        let result = strict_eq(&frame.accumulator, &rhs);
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+
+                    // TestUndetectable:
+                    //   Check if the accumulator is null or undefined (the two
+                    //   "undetectable" values in ECMAScript).
+                    Opcode::TestUndetectable => {
+                        let result =
+                            matches!(frame.accumulator, JsValue::Null | JsValue::Undefined);
+                        frame.accumulator = JsValue::Boolean(result);
+                    }
+
+                    // JumpIfJSReceiver [offset]:
+                    //   Jump if the accumulator is a JS receiver (object type, not
+                    //   null, undefined, or a primitive).
+                    Opcode::JumpIfJSReceiver => {
+                        let Operand::JumpOffset(delta) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfJSReceiver", 0));
+                        };
+                        if is_js_receiver(&frame.accumulator) {
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+
+                    // JumpIfJSReceiverConstant [idx]:
+                    //   Constant-pool variant of JumpIfJSReceiver.
+                    Opcode::JumpIfJSReceiverConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfJSReceiverConstant", 0));
+                        };
+                        if is_js_receiver(&frame.accumulator) {
+                            let delta =
+                                constant_pool_jump_delta(frame, idx, "JumpIfJSReceiverConstant")?;
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+
+                    // ToNumeric [feedback_slot]:
+                    //   Abstract ToNumeric operation — converts the accumulator to
+                    //   a numeric value (Number or BigInt).  BigInt values pass
+                    //   through unchanged.
+                    Opcode::ToNumeric => {
+                        // operands[0] is a FeedbackSlot, ignored at runtime.
+                        if !matches!(frame.accumulator, JsValue::BigInt(_)) {
+                            let n = frame.accumulator.to_number()?;
+                            frame.accumulator = number_to_jsvalue(n);
+                        }
+                    }
+
+                    // ── Wide / ExtraWide prefix opcodes ────────────────────────
+                    //
+                    // These are encoding prefixes consumed by the decoder; they
+                    // never appear as `instr.opcode` in the pre-decoded stream.
+                    Opcode::Wide | Opcode::ExtraWide => {
+                        return Err(StatorError::Internal(
+                            "Wide/ExtraWide prefix should not appear as a decoded opcode".into(),
+                        ));
+                    }
+
+                    // ── Constant-pool jump variants ───────────────────────────
+                    //
+                    // Each *Constant jump reads a constant-pool index whose
+                    // Number entry is the byte-level jump offset, then applies
+                    // the same condition as the non-constant counterpart.
+
+                    // JumpConstant [idx]: unconditional jump via constant pool.
+                    Opcode::JumpConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpConstant", 0));
+                        };
+                        let delta = constant_pool_jump_delta(frame, idx, "JumpConstant")?;
+                        frame.pc =
+                            resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                    }
+                    // JumpIfTrueConstant [idx]
+                    Opcode::JumpIfTrueConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfTrueConstant", 0));
+                        };
+                        if matches!(frame.accumulator, JsValue::Boolean(true)) {
+                            let delta = constant_pool_jump_delta(frame, idx, "JumpIfTrueConstant")?;
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    // JumpIfFalseConstant [idx]
+                    Opcode::JumpIfFalseConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfFalseConstant", 0));
+                        };
+                        if matches!(frame.accumulator, JsValue::Boolean(false)) {
+                            let delta =
+                                constant_pool_jump_delta(frame, idx, "JumpIfFalseConstant")?;
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    // JumpIfToBooleanTrueConstant [idx]
+                    Opcode::JumpIfToBooleanTrueConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfToBooleanTrueConstant", 0));
+                        };
+                        if frame.accumulator.to_boolean() {
+                            let delta = constant_pool_jump_delta(
+                                frame,
+                                idx,
+                                "JumpIfToBooleanTrueConstant",
+                            )?;
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    // JumpIfToBooleanFalseConstant [idx]
+                    Opcode::JumpIfToBooleanFalseConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfToBooleanFalseConstant", 0));
+                        };
+                        if !frame.accumulator.to_boolean() {
+                            let delta = constant_pool_jump_delta(
+                                frame,
+                                idx,
+                                "JumpIfToBooleanFalseConstant",
+                            )?;
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    // JumpIfNullConstant [idx]
+                    Opcode::JumpIfNullConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfNullConstant", 0));
+                        };
+                        if frame.accumulator.is_null() {
+                            let delta = constant_pool_jump_delta(frame, idx, "JumpIfNullConstant")?;
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    // JumpIfNotNullConstant [idx]
+                    Opcode::JumpIfNotNullConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfNotNullConstant", 0));
+                        };
+                        if !frame.accumulator.is_null() {
+                            let delta =
+                                constant_pool_jump_delta(frame, idx, "JumpIfNotNullConstant")?;
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    // JumpIfUndefinedConstant [idx]
+                    Opcode::JumpIfUndefinedConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfUndefinedConstant", 0));
+                        };
+                        if frame.accumulator.is_undefined() {
+                            let delta =
+                                constant_pool_jump_delta(frame, idx, "JumpIfUndefinedConstant")?;
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    // JumpIfNotUndefinedConstant [idx]
+                    Opcode::JumpIfNotUndefinedConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfNotUndefinedConstant", 0));
+                        };
+                        if !frame.accumulator.is_undefined() {
+                            let delta =
+                                constant_pool_jump_delta(frame, idx, "JumpIfNotUndefinedConstant")?;
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+                    // JumpIfUndefinedOrNullConstant [idx]
+                    Opcode::JumpIfUndefinedOrNullConstant => {
+                        let Operand::ConstantPoolIdx(idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("JumpIfUndefinedOrNullConstant", 0));
+                        };
+                        if frame.accumulator.is_nullish() {
+                            let delta = constant_pool_jump_delta(
+                                frame,
+                                idx,
+                                "JumpIfUndefinedOrNullConstant",
+                            )?;
+                            frame.pc =
+                                resolve_jump(frame.pc, delta, &byte_offsets, instructions.len())?;
+                        }
+                    }
+
+                    // ── Host integration calls ────────────────────────────────
+                    //
+                    // CallJSRuntime, InvokeIntrinsic, CallRuntimeForPair: these
+                    // call into the host runtime.  Currently treated as no-ops
+                    // (like CallRuntime) since the runtime functions they target
+                    // are optimisation hints or non-critical for correctness.
+
+                    // CallJSRuntime [context_idx, args_start, args_count]
+                    Opcode::CallJSRuntime => {
+                        let Operand::ConstantPoolIdx(_ctx_idx) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallJSRuntime", 0));
+                        };
+                        // No-op: accumulator is left unchanged.
+                    }
+                    // InvokeIntrinsic [function_id, args_start, args_count]
+                    Opcode::InvokeIntrinsic => {
+                        let Operand::RuntimeId(_runtime_id) = instr.operands[0] else {
+                            return Err(err_bad_operand("InvokeIntrinsic", 0));
+                        };
+                        // No-op: accumulator is left unchanged.
+                    }
+                    // CallRuntimeForPair [function_id, args_start, args_count, first_return]
+                    Opcode::CallRuntimeForPair => {
+                        let Operand::RuntimeId(_runtime_id) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallRuntimeForPair", 0));
+                        };
+                        // No-op: accumulator is left unchanged.
+                    }
+
+                    // ── ConstructForwardAllArgs ────────────────────────────────
+                    //
+                    // ConstructForwardAllArgs [constructor, slot]:
+                    //   Like Construct, but instead of reading args from an
+                    //   explicit register range, forward all parameter registers
+                    //   from the current frame to the callee.
+                    Opcode::ConstructForwardAllArgs => {
+                        let Operand::Register(ctor_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("ConstructForwardAllArgs", 0));
+                        };
+                        // operands[1] is a FeedbackSlot, ignored at runtime.
+                        let ctor = frame.read_reg(ctor_v)?.clone();
+                        let ctor_proto = proto_lookup(&ctor, "prototype");
+                        let param_count = frame.bytecode_array.parameter_count() as usize;
+                        let args: Vec<JsValue> =
+                            frame.registers.get(..param_count).unwrap_or(&[]).to_vec();
+                        match ctor {
+                            JsValue::Function(ba) => {
+                                let mut callee_frame = InterpreterFrame::new_with_globals(
+                                    (*ba).clone(),
+                                    args,
+                                    Rc::clone(&frame.global_env),
+                                );
+                                push_call_frame("<anonymous>")?;
+                                let result = Interpreter::run(&mut callee_frame);
+                                pop_call_frame();
+                                let val = result?;
+                                frame.accumulator = wire_construct_prototype(val, &ctor_proto);
+                            }
+                            JsValue::NativeFunction(f) => {
+                                frame.accumulator = f(args)?;
+                            }
+                            other => {
+                                return Err(StatorError::TypeError(format!(
+                                    "ConstructForwardAllArgs: constructor is not a function (got {other:?})"
+                                )));
+                            }
+                        }
+                    }
+
+                    // ── CollectTypeProfile ─────────────────────────────────────
+                    //
+                    // CollectTypeProfile [position]:
+                    //   Records type-profile information for the accumulator.
+                    //   This is a profiling-only instruction; a no-op for
+                    //   correctness.
+                    Opcode::CollectTypeProfile => {
+                        // No-op: operands[0] is an Immediate (position), ignored.
+                    }
+
+                    // ── CreateObjectFromIterable ──────────────────────────────
+                    //
+                    // CreateObjectFromIterable:
+                    //   Creates an object by spreading an iterable (e.g.
+                    //   `{...iterable}`).  Consumes the accumulator and creates a
+                    //   new PlainObject from its key-value pairs.
+                    Opcode::CreateObjectFromIterable => {
+                        let iterable = frame.accumulator.clone();
+                        let map: HashMap<String, JsValue> = match &iterable {
+                            JsValue::PlainObject(obj) => obj.borrow().clone(),
+                            JsValue::Array(arr) => {
+                                let mut m = HashMap::new();
+                                for (i, v) in arr.iter().enumerate() {
+                                    m.insert(i.to_string(), v.clone());
+                                }
+                                m.insert("length".to_string(), JsValue::Smi(arr.len() as i32));
+                                m
+                            }
+                            JsValue::Iterator(iter) => {
+                                let mut m = HashMap::new();
+                                let mut idx = 0usize;
+                                loop {
+                                    let mut it = iter.borrow_mut();
+                                    match it.next_item() {
+                                        Some(v) => {
+                                            m.insert(idx.to_string(), v);
+                                            idx += 1;
+                                        }
+                                        None => break,
+                                    }
+                                }
+                                m.insert("length".to_string(), JsValue::Smi(idx as i32));
+                                m
+                            }
+                            _ => HashMap::new(),
+                        };
+                        frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
+                    }
+
+                    // ── CallDirectEval ────────────────────────────────────────
+                    // Emitted when the callee is the bare identifier `eval`.
+                    // At runtime: if the callee is still the built-in eval
+                    // function, execute the source sharing the caller's
+                    // `global_env` (direct eval); otherwise fall through to a
+                    // normal function call.
+                    Opcode::CallDirectEval => {
+                        let Operand::Register(callee_v) = instr.operands[0] else {
+                            return Err(err_bad_operand("CallDirectEval", 0));
+                        };
+                        let Operand::Register(args_start_v) = instr.operands[1] else {
+                            return Err(err_bad_operand("CallDirectEval", 1));
+                        };
+                        let Operand::RegisterCount(arg_count) = instr.operands[2] else {
+                            return Err(err_bad_operand("CallDirectEval", 2));
+                        };
+                        let callee = frame.read_reg(callee_v)?.clone();
+                        let args = collect_args(frame, args_start_v, arg_count)?;
+
+                        // Check whether the callee is the original built-in eval
+                        // by comparing the Rc pointer with the one stored in the
+                        // global environment under "eval".
+                        let is_builtin = if let JsValue::NativeFunction(ref callee_fn) = callee {
+                            if let Some(JsValue::NativeFunction(ref global_fn)) =
+                                frame.global_env.borrow().get("eval").cloned()
+                            {
+                                Rc::ptr_eq(callee_fn, global_fn)
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
+                        };
+
+                        if is_builtin {
+                            // Direct eval semantics (ECMAScript §19.2.1.1).
+                            // Non-string arg → return as-is; no arg → undefined.
+                            let source = match args.first() {
+                                Some(JsValue::String(s)) => s.clone(),
+                                Some(other) => {
+                                    frame.accumulator = other.clone();
+                                    continue;
+                                }
+                                None => {
+                                    frame.accumulator = JsValue::Undefined;
+                                    continue;
+                                }
+                            };
+                            frame.accumulator = crate::builtins::global::global_eval_direct(
+                                &source,
+                                Rc::clone(&frame.global_env),
+                            )?;
+                        } else {
+                            // Callee was reassigned — fall through to normal call.
+                            match callee {
+                                JsValue::Function(ba) => {
+                                    if ba.is_generator() {
+                                        frame.accumulator =
+                                            JsValue::Generator(GeneratorState::new((*ba).clone()));
+                                    } else {
+                                        let mut callee_frame = InterpreterFrame::new_with_globals(
+                                            (*ba).clone(),
+                                            args,
+                                            Rc::clone(&frame.global_env),
+                                        );
+                                        let _ = push_call_frame("<eval-fallback>");
+                                        let result = Interpreter::run(&mut callee_frame);
+                                        pop_call_frame();
+                                        frame.accumulator = result?;
+                                    }
+                                }
+                                JsValue::NativeFunction(f) => {
+                                    frame.accumulator = f(args)?;
+                                }
+                                JsValue::PlainObject(ref map) => {
+                                    if let Some(JsValue::NativeFunction(f)) =
+                                        map.borrow().get("__call__").cloned()
+                                    {
+                                        frame.accumulator = f(args)?;
+                                    } else {
+                                        return Err(StatorError::TypeError(
+                                        "CallDirectEval: callee is not a function (got PlainObject)"
+                                            .to_string(),
+                                    ));
+                                    }
+                                }
+                                other => {
+                                    return Err(StatorError::TypeError(format!(
+                                        "CallDirectEval: callee is not a function (got {other:?})"
+                                    )));
+                                }
+                            }
+                        }
+                    }
+
+                    // ── Unimplemented ──────────────────────────────────────────
+                    other => {
+                        return Err(StatorError::Internal(format!(
+                            "unimplemented opcode: {other:?}"
+                        )));
+                    }
                 }
             }
-        }
+        } // 'tail_call
     }
 
     /// Execute one step of a generator function.
@@ -12097,5 +12246,69 @@ mod tests {
         } else {
             panic!("expected Promise, got {result:?}");
         }
+    }
+
+    // ── Tail call optimisation ────────────────────────────────────────────────
+
+    #[test]
+    fn test_tail_call_direct_recursion() {
+        // `return f(n-1, acc+n)` is a direct tail call — it should reuse
+        // the frame and not overflow the call stack even for large N.
+        let result = crate::builtins::global::global_eval(
+            "function sum(n, acc) { \
+               if (n <= 0) return acc; \
+               return sum(n - 1, acc + n); \
+             } \
+             sum(50000, 0)",
+        )
+        .unwrap();
+        // 50000 * 50001 / 2 = 1_250_025_000 (fits in i32)
+        assert_eq!(result, JsValue::Smi(1_250_025_000));
+    }
+
+    #[test]
+    fn test_tail_call_conditional() {
+        // Both branches of the ternary are in tail position.
+        let result = crate::builtins::global::global_eval(
+            "function even(n) { \
+               if (n === 0) return true; \
+               return odd(n - 1); \
+             } \
+             function odd(n) { \
+               if (n === 0) return false; \
+               return even(n - 1); \
+             } \
+             even(100000)",
+        )
+        .unwrap();
+        assert_eq!(result, JsValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_tail_call_non_tail_not_optimised() {
+        // `n + f(n-1)` is NOT a tail call — the call result feeds into `+`.
+        // This should work correctly (not be incorrectly optimised).
+        let result = crate::builtins::global::global_eval(
+            "function sum(n) { \
+               if (n <= 0) return 0; \
+               return n + sum(n - 1); \
+             } \
+             sum(10)",
+        )
+        .unwrap();
+        assert_eq!(result, JsValue::Smi(55));
+    }
+
+    #[test]
+    fn test_tail_call_conditional_ternary() {
+        // `return cond ? f() : g()` — both branches are tail calls.
+        let result = crate::builtins::global::global_eval(
+            "function countdown(n) { \
+               return n <= 0 ? 'done' : countdown(n - 1); \
+             } \
+             countdown(50000)",
+        )
+        .unwrap();
+        assert_eq!(result, JsValue::String("done".to_string()));
     }
 }

--- a/crates/stator_test262/src/main.rs
+++ b/crates/stator_test262/src/main.rs
@@ -340,8 +340,6 @@ const UNSUPPORTED_FEATURES: &[&str] = &[
     "regexp-v-flag",
     // Internationalisation
     "Intl",
-    // Tail-call optimisation
-    "tail-call-optimization",
     // Miscellaneous
     "globalThis",
 ];


### PR DESCRIPTION
## Summary

Implement proper tail calls (PTC) per ES2015 spec, making Stator the second JS engine (after Safari/JSC) to support this feature.

## Changes

### Bytecode
- **New \TailCall\ opcode** in \ytecodes.rs\ — same operand layout as \CallAnyReceiver\ (\[callable, args_start, args_count, slot]\)

### Bytecode Generator (\ytecode_generator.rs\)
- **\in_tail_position\ flag** on \FunctionCompiler\ — set by \compile_return\, consumed by \compile_call\
- **Tail position propagation** through \compile_conditional\ (both branches), \compile_logical\ (right operand), and \compile_sequence\ (last expression)
- **Guard against false positives** — \compile_expr\ clears the flag for non-propagating expression types (e.g. \Binary\, \Unary\, etc.) so \eturn n + f(n-1)\ is not incorrectly optimized

### Interpreter (\interpreter/mod.rs\)
- **Trampoline loop** (\'tail_call\) wrapping the dispatch loop — when \TailCall\ is encountered, the frame is reset in-place (new bytecode, registers, PC) and the outer loop re-decodes
- **No new frame allocation** for tail calls — prevents stack growth for recursive patterns
- **Generators/async fallback** — \TailCall\ of generator or async functions falls back to normal call semantics

### Test262
- Removed \	ail-call-optimization\ from the unsupported features skip list

## Tests
- \	est_tail_call_direct_recursion\ — 50,000 deep recursion with accumulator pattern
- \	est_tail_call_conditional\ — mutual recursion (even/odd) 100,000 deep
- \	est_tail_call_conditional_ternary\ — ternary tail call 50,000 deep
- \	est_tail_call_non_tail_not_optimised\ — verifies \
 + f(n-1)\ is NOT incorrectly tail-call-optimized

Closes #309