### PR TITLE
chore: enable implemented features in Test262 compliance gate

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -47,10 +47,11 @@ jobs:
         run: cargo build --package stator_test262 --release
 
       - name: Run Test262 suite
-        # Threshold raised as engine conformance improves.
-        # Current measured pass rate: ~14% (install_globals + native harness
-        # + spec-compliant [[Construct]] + PlainObject constructor support).
+        # Threshold tracks conformance progress. Features enabled:
+        # async, generators, classes, symbols, BigInt, destructuring,
+        # for-of, dynamic-import, Proxy/Reflect, WeakRef, Intl, RegExp
+        # advanced, tail-call-optimization, globalThis.
         run: |
           ./target/release/stator_test262 \
             --test262-dir test262 \
-            --threshold 10.0
+            --threshold 25.0

--- a/crates/stator_test262/src/main.rs
+++ b/crates/stator_test262/src/main.rs
@@ -281,82 +281,28 @@ impl HarnessCache {
 /// skipped rather than run-and-failed, keeping the measured pass rate
 /// meaningful.
 const UNSUPPORTED_FEATURES: &[&str] = &[
-    // Async / generators
-    "async-functions",
-    "async-iteration",
-    "generators",
+    // Async: partially implemented but not yet robust enough for Test262
     "top-level-await",
-    // Classes
-    "class",
-    "class-fields-private",
-    "class-fields-public",
-    "class-methods-private",
-    "class-static-block",
-    "class-static-fields-private",
-    "class-static-fields-public",
-    "class-static-methods-private",
-    // Symbols
-    "Symbol",
-    "Symbol.asyncIterator",
-    "Symbol.hasInstance",
-    "Symbol.isConcatSpreadable",
-    "Symbol.iterator",
-    "Symbol.match",
-    "Symbol.matchAll",
-    "Symbol.replace",
-    "Symbol.search",
-    "Symbol.species",
-    "Symbol.split",
-    "Symbol.toPrimitive",
-    "Symbol.toStringTag",
-    "Symbol.unscopables",
-    // Proxy / Reflect
-    "Proxy",
-    "Reflect",
-    "Reflect.construct",
-    // BigInt
-    "BigInt",
-    // Modules
-    "arbitrary-module-namespace-names",
-    "dynamic-import",
-    "export-star-as-namespace-from-module",
-    "import-assertions",
-    "import-attributes",
-    "import.meta",
-    // SharedArrayBuffer / Atomics
+    // SharedArrayBuffer / Atomics — not implemented
     "Atomics",
     "SharedArrayBuffer",
-    // WeakRef / FinalizationRegistry
-    "FinalizationRegistry",
-    "WeakRef",
-    // Advanced RegExp
-    "regexp-dotall",
-    "regexp-lookbehind",
-    "regexp-match-indices",
-    "regexp-named-groups",
+    // Advanced RegExp features not yet fully supported
     "regexp-unicode-property-escapes",
     "regexp-v-flag",
-    // Internationalisation
-    "Intl",
-    // Temporal (draft proposal — requires `super`, `class`, advanced object model)
+    // Temporal (stage 3 proposal — very large surface area)
     "Temporal",
-    // Destructuring (not yet compiled)
-    "destructuring-binding",
-    "destructuring-assignment",
-    // Miscellaneous
-    "globalThis",
-    // Tail calls
-    "tail-call-optimization",
-    // TypedArrays / ArrayBuffer
+    // TypedArrays / ArrayBuffer — not implemented
     "TypedArray",
     "ArrayBuffer",
     "DataView",
     "resizable-arraybuffer",
-    // For-of / spread / iterators (require Symbol.iterator)
-    "for-of",
-    // ShadowRealm / Disposable
+    // ShadowRealm / Disposable — not implemented
     "ShadowRealm",
     "explicit-resource-management",
+    // Module features that need runtime module loader
+    "arbitrary-module-namespace-names",
+    "import-assertions",
+    "import-attributes",
 ];
 
 /// Returns `true` when the feature list contains at least one unsupported tag.


### PR DESCRIPTION
## Summary
Remove 40+ feature tags from the Test262 UNSUPPORTED_FEATURES skip list that have been implemented across PRs #318-#381.

**Features now enabled for testing:**
- Async functions, async iteration, generators
- Classes (all variants: private fields, static blocks, static methods)
- Symbols (all well-known symbols)
- BigInt
- Destructuring (binding + assignment)
- for-of
- Dynamic import, import.meta, export-star-as-namespace
- Proxy/Reflect
- WeakRef/FinalizationRegistry
- Intl
- RegExp (dotAll, lookbehind, match-indices, named-groups)
- Tail call optimization
- globalThis

**Still skipped (not yet implemented):**
- top-level-await
- Atomics/SharedArrayBuffer
- regexp-unicode-property-escapes, regexp-v-flag
- Temporal
- TypedArray/ArrayBuffer/DataView
- ShadowRealm, explicit-resource-management
- import-assertions/attributes

**CI threshold**: Raised from 10% to 25%.