### PR TITLE
feat: property attribute enforcement (closes #385)

### DIFF
--- a/crates/st8/src/main.rs
+++ b/crates/st8/src/main.rs
@@ -20,6 +20,7 @@
 //!   newline, to standard output.
 //! - `console.log(...args)` — alias for `print`.
 
+use stator_core::objects::property_map::PropertyMap;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::process;
@@ -197,7 +198,7 @@ fn build_globals() -> Rc<RefCell<HashMap<String, JsValue>>> {
     );
 
     // console.log(...args) — alias for print
-    let console_obj: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let console_obj: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
     console_obj.borrow_mut().insert(
         "log".to_string(),
         JsValue::NativeFunction(Rc::new(print_args)),

--- a/crates/stator_core/src/builtins/function.rs
+++ b/crates/stator_core/src/builtins/function.rs
@@ -515,9 +515,9 @@ mod tests {
 
     #[test]
     fn test_has_instance_object_like() {
+        use crate::objects::property_map::PropertyMap;
         use std::cell::RefCell;
-        use std::collections::HashMap;
-        let obj = JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
+        let obj = JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new())));
         assert!(function_has_instance(&obj, &JsValue::Undefined));
     }
 

--- a/crates/stator_core/src/builtins/install_globals.rs
+++ b/crates/stator_core/src/builtins/install_globals.rs
@@ -111,6 +111,7 @@ use crate::builtins::weak_set::{weak_set_add, weak_set_delete, weak_set_has, wea
 use crate::error::{StatorError, StatorResult};
 use crate::objects::js_object::JsObject;
 use crate::objects::map::PropertyAttributes;
+use crate::objects::property_map::PropertyMap;
 use crate::objects::value::JsValue;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -236,7 +237,7 @@ fn arg_f64(args: &[JsValue], idx: usize) -> StatorResult<f64> {
 
 /// Build the `Math` namespace object with all constants and methods.
 fn make_math() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ── Constants ────────────────────────────────────────────────────────
     props.insert("E".into(), JsValue::HeapNumber(MATH_E));
@@ -427,7 +428,7 @@ fn make_math() -> JsValue {
 
 /// Build the `console` namespace object.
 fn make_console() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     props.insert(
         "log".into(),
@@ -480,7 +481,7 @@ fn json_value_to_js_value(jv: &crate::builtins::json::JsonValue) -> JsValue {
             JsValue::Array(Rc::new(items))
         }
         JsonValue::Object(entries) => {
-            let mut map = HashMap::new();
+            let mut map = PropertyMap::new();
             for (k, v) in entries.borrow().iter() {
                 map.insert(k.clone(), json_value_to_js_value(v));
             }
@@ -503,7 +504,7 @@ fn make_json() -> JsValue {
         JsonReplacer, JsonSpace, JsonValue, js_value_to_json, json_parse, json_stringify_js_value,
     };
 
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     props.insert(
         "parse".into(),
@@ -632,7 +633,7 @@ fn apply_js_reviver(
 /// - `parse`: `Date.parse(string)`
 /// - `UTC`: `Date.UTC(year, month, ...)`
 fn make_date() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ── Constructor: new Date() / Date(value) / Date(y, m, d, ...) ──────
     props.insert(
@@ -744,7 +745,7 @@ fn make_date() -> JsValue {
 /// that all getter/setter methods close over.
 fn make_date_instance(t: f64) -> JsValue {
     let inner = Rc::new(RefCell::new(t));
-    let mut obj: HashMap<String, JsValue> = HashMap::new();
+    let mut obj = PropertyMap::new();
 
     // ── getTime / valueOf ────────────────────────────────────────────────
     {
@@ -1241,7 +1242,7 @@ fn make_date_instance(t: f64) -> JsValue {
 
 /// Build the `Number` constructor/namespace object.
 fn make_number() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // Number.isNaN — does NOT coerce (unlike global isNaN)
     props.insert(
@@ -1347,7 +1348,7 @@ fn make_number() -> JsValue {
 
 /// Build the `Object` constructor/namespace object.
 fn make_object() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     props.insert(
         "keys".into(),
@@ -1370,7 +1371,7 @@ fn make_object() -> JsValue {
         native(|args| {
             let val = args.first().unwrap_or(&JsValue::Undefined);
             if let JsValue::PlainObject(map) = val {
-                let values: Vec<JsValue> = map.borrow().values().cloned().collect();
+                let values: Vec<JsValue> = map.borrow().iter().map(|(_, v)| v.clone()).collect();
                 Ok(JsValue::Array(Rc::new(values)))
             } else {
                 Ok(JsValue::Array(Rc::new(vec![])))
@@ -1437,7 +1438,7 @@ fn make_object() -> JsValue {
             if let JsValue::PlainObject(map) = obj {
                 let borrowed = map.borrow();
                 if let Some(value) = borrowed.get(&key) {
-                    let mut desc: HashMap<String, JsValue> = HashMap::new();
+                    let mut desc = PropertyMap::new();
                     desc.insert("value".into(), value.clone());
                     desc.insert("writable".into(), JsValue::Boolean(true));
                     desc.insert("enumerable".into(), JsValue::Boolean(true));
@@ -1574,7 +1575,7 @@ fn make_object() -> JsValue {
         "create".into(),
         native(|args| {
             let proto = args.first().unwrap_or(&JsValue::Undefined);
-            let mut obj: HashMap<String, JsValue> = HashMap::new();
+            let mut obj = PropertyMap::new();
             match proto {
                 JsValue::Null | JsValue::Undefined => {}
                 _ => {
@@ -1633,7 +1634,7 @@ fn make_object() -> JsValue {
         "fromEntries".into(),
         native(|args| {
             let iterable = args.first().unwrap_or(&JsValue::Undefined);
-            let mut result: HashMap<String, JsValue> = HashMap::new();
+            let mut result = PropertyMap::new();
 
             if let JsValue::Array(arr) = iterable {
                 for entry in arr.iter() {
@@ -1751,9 +1752,9 @@ fn make_object() -> JsValue {
         native(|args| {
             let obj = args.first().unwrap_or(&JsValue::Undefined);
             if let JsValue::PlainObject(map) = obj {
-                let mut result: HashMap<String, JsValue> = HashMap::new();
+                let mut result = PropertyMap::new();
                 for (key, value) in map.borrow().iter() {
-                    let mut desc: HashMap<String, JsValue> = HashMap::new();
+                    let mut desc = PropertyMap::new();
                     desc.insert("value".into(), value.clone());
                     desc.insert("writable".into(), JsValue::Boolean(true));
                     desc.insert("enumerable".into(), JsValue::Boolean(true));
@@ -1765,7 +1766,9 @@ fn make_object() -> JsValue {
                 }
                 Ok(JsValue::PlainObject(Rc::new(RefCell::new(result))))
             } else {
-                Ok(JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new()))))
+                Ok(JsValue::PlainObject(Rc::new(RefCell::new(
+                    PropertyMap::new(),
+                ))))
             }
         }),
     );
@@ -1780,7 +1783,7 @@ fn make_object() -> JsValue {
     );
 
     // ── Object.prototype ─────────────────────────────────────────────────
-    let mut obj_proto: HashMap<String, JsValue> = HashMap::new();
+    let mut obj_proto = PropertyMap::new();
 
     // Object.prototype.hasOwnProperty(key)
     obj_proto.insert(
@@ -1847,7 +1850,7 @@ fn make_object() -> JsValue {
 /// - `of` — `Array.of(...items)`.
 /// - `prototype` — an object with all `Array.prototype.*` methods.
 fn make_array() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ── Static methods ──────────────────────────────────────────────────
 
@@ -1887,7 +1890,7 @@ fn make_array() -> JsValue {
     // parameters.  The interpreter rewrites `arr.push(x)` into
     // `Array.prototype.push(arr, x)` at the bytecode level.
 
-    let mut proto: HashMap<String, JsValue> = HashMap::new();
+    let mut proto = PropertyMap::new();
 
     // push(...items)
     proto.insert(
@@ -2777,7 +2780,7 @@ fn make_array() -> JsValue {
 /// creates symbols, and the static properties are patched onto the
 /// surrounding `PlainObject` wrapper.
 fn make_symbol() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ── Static methods ────────────────────────────────────────────────────
 
@@ -2832,7 +2835,7 @@ fn make_symbol() -> JsValue {
 
     // ── Symbol.prototype ─────────────────────────────────────────────────
     {
-        let mut proto: HashMap<String, JsValue> = HashMap::new();
+        let mut proto = PropertyMap::new();
 
         // Symbol.prototype.description — getter returning the description.
         proto.insert(
@@ -2920,7 +2923,7 @@ fn make_symbol() -> JsValue {
 
 /// Build the `Iterator` constructor/namespace object with prototype helpers.
 fn make_iterator() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ── Static method: Iterator.from ──────────────────────────────────────
     props.insert(
@@ -2937,7 +2940,7 @@ fn make_iterator() -> JsValue {
     // attach them as own properties so that `Iterator.prototype.map(…)` is
     // accessible as `Iterator.map(iter, mapper)` for direct testing and for
     // the bytecode to call via property lookup.
-    let mut proto: HashMap<String, JsValue> = HashMap::new();
+    let mut proto = PropertyMap::new();
 
     proto.insert(
         "map".into(),
@@ -3051,7 +3054,7 @@ fn make_iterator() -> JsValue {
 fn make_async_iterator() -> JsValue {
     use crate::builtins::promise::MicrotaskQueue;
 
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
     let queue = MicrotaskQueue::new();
 
     // ── Static method: AsyncIterator.from ─────────────────────────────────
@@ -3067,7 +3070,7 @@ fn make_async_iterator() -> JsValue {
     }
 
     // ── Prototype (instance) methods ─────────────────────────────────────
-    let mut proto: HashMap<String, JsValue> = HashMap::new();
+    let mut proto = PropertyMap::new();
 
     {
         let q = queue.clone();
@@ -3216,7 +3219,7 @@ fn make_async_iterator() -> JsValue {
 /// methods (`get`, `set`, `has`, `delete`, `clear`, `forEach`, `keys`,
 /// `values`, `entries`, `size`).
 fn make_map_builtin() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ── Constructor: new Map() / new Map(iterable) ───────────────────────
     props.insert(
@@ -3237,7 +3240,7 @@ fn make_map_builtin() -> JsValue {
             };
             // Store the JsMap in a RefCell so prototype methods can mutate it.
             let inner = Rc::new(RefCell::new(m));
-            let mut obj: HashMap<String, JsValue> = HashMap::new();
+            let mut obj = PropertyMap::new();
             // size getter
             {
                 let inner = Rc::clone(&inner);
@@ -3385,7 +3388,7 @@ fn make_map_builtin() -> JsValue {
 /// (`add`, `has`, `delete`, `clear`, `forEach`, `keys`, `values`,
 /// `entries`, `size`).
 fn make_set_builtin() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ── Constructor: new Set() / new Set(iterable) ───────────────────────
     props.insert(
@@ -3397,7 +3400,7 @@ fn make_set_builtin() -> JsValue {
                 set_new()
             };
             let inner = Rc::new(RefCell::new(s));
-            let mut obj: HashMap<String, JsValue> = HashMap::new();
+            let mut obj = PropertyMap::new();
             // size getter
             {
                 let inner = Rc::clone(&inner);
@@ -3533,13 +3536,13 @@ fn make_set_builtin() -> JsValue {
 /// `delete`).  Keys must be `Object` pointers; non-object keys cause a
 /// `TypeError`.
 fn make_weak_map_builtin() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     props.insert(
         "__call__".into(),
         native(|_args| {
             let inner = Rc::new(RefCell::new(weak_map_new()));
-            let mut obj: HashMap<String, JsValue> = HashMap::new();
+            let mut obj = PropertyMap::new();
 
             // get(key)
             {
@@ -3624,13 +3627,13 @@ fn make_weak_map_builtin() -> JsValue {
 /// a new `WeakSet` instance with prototype methods (`add`, `has`, `delete`).
 /// Values must be `Object` pointers; non-object values cause a `TypeError`.
 fn make_weak_set_builtin() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     props.insert(
         "__call__".into(),
         native(|_args| {
             let inner = Rc::new(RefCell::new(weak_set_new()));
-            let mut obj: HashMap<String, JsValue> = HashMap::new();
+            let mut obj = PropertyMap::new();
 
             // add(value)
             {
@@ -3699,7 +3702,7 @@ fn make_weak_set_builtin() -> JsValue {
 /// a new `WeakRef` instance with a `deref` prototype method.  The target
 /// must be an `Object` pointer; non-object targets cause a `TypeError`.
 fn make_weak_ref_builtin() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     props.insert(
         "__call__".into(),
@@ -3707,7 +3710,7 @@ fn make_weak_ref_builtin() -> JsValue {
             let target = args.first().unwrap_or(&JsValue::Undefined);
             if let JsValue::Object(ptr) = target {
                 let inner = Rc::new(RefCell::new(weak_ref_new(*ptr)?));
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
 
                 // deref()
                 {
@@ -3739,7 +3742,7 @@ fn make_weak_ref_builtin() -> JsValue {
 /// prototype methods.  The cleanup callback is stored as a JS-level value;
 /// actual invocation happens when the GC integration is complete.
 fn make_finalization_registry_builtin() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     props.insert(
         "__call__".into(),
@@ -3753,7 +3756,7 @@ fn make_finalization_registry_builtin() -> JsValue {
 
             let inner = Rc::new(RefCell::new(finalization_registry_new()));
             let callback = Rc::new(callback);
-            let mut obj: HashMap<String, JsValue> = HashMap::new();
+            let mut obj = PropertyMap::new();
 
             // register(target, heldValue [, unregisterToken])
             {
@@ -3863,7 +3866,7 @@ fn make_finalization_registry_builtin() -> JsValue {
 /// - `prototype` — an object with `bind`, `call`, `apply`, `toString`,
 ///   `Symbol.hasInstance`, `name`, and `length`.
 fn make_function() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ── Constructor: new Function(…args, body) ──────────────────────────
     props.insert(
@@ -3872,7 +3875,7 @@ fn make_function() -> JsValue {
     );
 
     // ── Function.prototype ──────────────────────────────────────────────
-    let mut proto: HashMap<String, JsValue> = HashMap::new();
+    let mut proto = PropertyMap::new();
 
     // Function.prototype.call(thisArg, ...args)
     proto.insert(
@@ -3983,7 +3986,7 @@ fn make_function() -> JsValue {
 /// - Static methods: `fromCharCode`, `fromCodePoint`, `raw`.
 /// - `prototype` — an object with all `String.prototype.*` methods.
 fn make_string() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ── Callable: String(value) ─────────────────────────────────────────
     props.insert(
@@ -4052,7 +4055,7 @@ fn make_string() -> JsValue {
     );
 
     // ── Prototype methods ───────────────────────────────────────────────
-    let mut proto: HashMap<String, JsValue> = HashMap::new();
+    let mut proto = PropertyMap::new();
 
     // charAt(pos)
     proto.insert(
@@ -4681,7 +4684,7 @@ fn make_promise() -> JsValue {
         promise_with_resolvers,
     };
 
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
     let queue = MicrotaskQueue::new();
 
     // ── Constructor: new Promise(executor) ─────────────────────────────────
@@ -4812,7 +4815,7 @@ fn make_promise() -> JsValue {
                 let wr = promise_with_resolvers(&q);
                 let resolve_box = Rc::new(RefCell::new(Some(wr.resolve)));
                 let reject_box = Rc::new(RefCell::new(Some(wr.reject)));
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
                 obj.insert("promise".into(), JsValue::Promise(wr.promise));
                 obj.insert(
                     "resolve".into(),
@@ -4932,7 +4935,7 @@ fn make_promise() -> JsValue {
 
 /// Build the `RegExp` constructor.
 fn make_regexp() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // Callable: new RegExp(pattern, flags)
     props.insert("__call__".into(), native(|args| regexp_construct(&args)));
@@ -4952,7 +4955,7 @@ fn make_regexp() -> JsValue {
 
 /// Build the `BigInt` global constructor with `asIntN` and `asUintN` static methods.
 fn make_bigint() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // BigInt(value) — callable constructor (must not be called with `new`)
     props.insert(
@@ -5104,20 +5107,20 @@ fn extract_handler(val: &JsValue) -> Option<crate::builtins::promise::PromiseHan
 /// that returns an instance (another `PlainObject`) carrying a `format` (or
 /// `compare` / `select`) method.
 fn make_intl() -> JsValue {
-    let mut ns: HashMap<String, JsValue> = HashMap::new();
+    let mut ns = PropertyMap::new();
 
     // ── Intl.NumberFormat ────────────────────────────────────────────────
     ns.insert("NumberFormat".into(), {
-        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        let mut ctor = PropertyMap::new();
         ctor.insert(
             "__call__".into(),
             native(|_args| {
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
                 obj.insert("format".into(), native(|a| number_format_js(&a)));
                 obj.insert(
                     "resolvedOptions".into(),
                     native(|_| {
-                        let mut opts: HashMap<String, JsValue> = HashMap::new();
+                        let mut opts = PropertyMap::new();
                         opts.insert("locale".into(), JsValue::String("en-US".into()));
                         opts.insert("numberingSystem".into(), JsValue::String("latn".into()));
                         Ok(JsValue::PlainObject(Rc::new(RefCell::new(opts))))
@@ -5131,16 +5134,16 @@ fn make_intl() -> JsValue {
 
     // ── Intl.DateTimeFormat ──────────────────────────────────────────────
     ns.insert("DateTimeFormat".into(), {
-        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        let mut ctor = PropertyMap::new();
         ctor.insert(
             "__call__".into(),
             native(|_args| {
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
                 obj.insert("format".into(), native(|a| date_time_format_js(&a)));
                 obj.insert(
                     "resolvedOptions".into(),
                     native(|_| {
-                        let mut opts: HashMap<String, JsValue> = HashMap::new();
+                        let mut opts = PropertyMap::new();
                         opts.insert("locale".into(), JsValue::String("en-US".into()));
                         opts.insert("calendar".into(), JsValue::String("gregory".into()));
                         opts.insert("timeZone".into(), JsValue::String("UTC".into()));
@@ -5155,16 +5158,16 @@ fn make_intl() -> JsValue {
 
     // ── Intl.Collator ───────────────────────────────────────────────────
     ns.insert("Collator".into(), {
-        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        let mut ctor = PropertyMap::new();
         ctor.insert(
             "__call__".into(),
             native(|_args| {
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
                 obj.insert("compare".into(), native(|a| collator_compare_js(&a)));
                 obj.insert(
                     "resolvedOptions".into(),
                     native(|_| {
-                        let mut opts: HashMap<String, JsValue> = HashMap::new();
+                        let mut opts = PropertyMap::new();
                         opts.insert("locale".into(), JsValue::String("en-US".into()));
                         opts.insert("sensitivity".into(), JsValue::String("variant".into()));
                         Ok(JsValue::PlainObject(Rc::new(RefCell::new(opts))))
@@ -5178,16 +5181,16 @@ fn make_intl() -> JsValue {
 
     // ── Intl.PluralRules ────────────────────────────────────────────────
     ns.insert("PluralRules".into(), {
-        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        let mut ctor = PropertyMap::new();
         ctor.insert(
             "__call__".into(),
             native(|_args| {
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
                 obj.insert("select".into(), native(|a| plural_rules_select_js(&a)));
                 obj.insert(
                     "resolvedOptions".into(),
                     native(|_| {
-                        let mut opts: HashMap<String, JsValue> = HashMap::new();
+                        let mut opts = PropertyMap::new();
                         opts.insert("locale".into(), JsValue::String("en-US".into()));
                         opts.insert("type".into(), JsValue::String("cardinal".into()));
                         Ok(JsValue::PlainObject(Rc::new(RefCell::new(opts))))
@@ -5201,7 +5204,7 @@ fn make_intl() -> JsValue {
 
     // ── Intl.ListFormat ─────────────────────────────────────────────────
     ns.insert("ListFormat".into(), {
-        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        let mut ctor = PropertyMap::new();
         ctor.insert(
             "__call__".into(),
             native(|args| {
@@ -5219,7 +5222,7 @@ fn make_intl() -> JsValue {
                 } else {
                     "conjunction".to_string()
                 };
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
                 obj.insert(
                     "format".into(),
                     native(move |a| list_format_js(&a, &list_type)),
@@ -5232,11 +5235,11 @@ fn make_intl() -> JsValue {
 
     // ── Intl.RelativeTimeFormat ─────────────────────────────────────────
     ns.insert("RelativeTimeFormat".into(), {
-        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        let mut ctor = PropertyMap::new();
         ctor.insert(
             "__call__".into(),
             native(|_args| {
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
                 obj.insert("format".into(), native(|a| relative_time_format_js(&a)));
                 Ok(JsValue::PlainObject(Rc::new(RefCell::new(obj))))
             }),
@@ -5246,11 +5249,11 @@ fn make_intl() -> JsValue {
 
     // ── Intl.Segmenter ──────────────────────────────────────────────────
     ns.insert("Segmenter".into(), {
-        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        let mut ctor = PropertyMap::new();
         ctor.insert(
             "__call__".into(),
             native(|_args| {
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
                 obj.insert(
                     "segment".into(),
                     native(|a| {
@@ -5270,11 +5273,11 @@ fn make_intl() -> JsValue {
 
     // ── Intl.DisplayNames ───────────────────────────────────────────────
     ns.insert("DisplayNames".into(), {
-        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        let mut ctor = PropertyMap::new();
         ctor.insert(
             "__call__".into(),
             native(|_args| {
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
                 obj.insert(
                     "of".into(),
                     native(|a| {
@@ -5290,12 +5293,12 @@ fn make_intl() -> JsValue {
 
     // ── Intl.Locale ─────────────────────────────────────────────────────
     ns.insert("Locale".into(), {
-        let mut ctor: HashMap<String, JsValue> = HashMap::new();
+        let mut ctor = PropertyMap::new();
         ctor.insert(
             "__call__".into(),
             native(|args| {
                 let tag = args.first().unwrap_or(&JsValue::Undefined).to_js_string()?;
-                let mut obj: HashMap<String, JsValue> = HashMap::new();
+                let mut obj = PropertyMap::new();
                 obj.insert("language".into(), JsValue::String(locale_language(&tag)));
                 obj.insert("baseName".into(), JsValue::String(locale_base_name(&tag)));
                 obj.insert(
@@ -5355,7 +5358,7 @@ fn make_intl() -> JsValue {
 /// Provides `Proxy(target, handler)` as a callable constructor and
 /// `Proxy.revocable(target, handler)` as a static method.
 fn make_proxy() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // Proxy as a constructor: new Proxy(target, handler)
     props.insert(
@@ -5413,7 +5416,7 @@ fn make_proxy() -> JsValue {
                 proxy_revoke(&mut proxy_rc.borrow_mut());
                 Ok(JsValue::Undefined)
             }));
-            let mut result = HashMap::new();
+            let mut result = PropertyMap::new();
             result.insert("proxy".to_string(), proxy_val);
             result.insert("revoke".to_string(), revoke_fn);
             Ok(JsValue::PlainObject(Rc::new(RefCell::new(result))))
@@ -5473,7 +5476,7 @@ fn build_proxy_handler(handler_val: &JsValue) -> ProxyHandler {
 
 /// Build the `Reflect` namespace object with all 13 static methods.
 fn make_reflect() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     props.insert(
         "get".into(),
@@ -5540,7 +5543,7 @@ fn make_reflect() -> JsValue {
             let key = args.get(1).unwrap_or(&JsValue::Undefined).to_js_string()?;
             match reflect_get_own_property_descriptor(&target, &key) {
                 Some((val, attrs)) => {
-                    let mut desc = HashMap::new();
+                    let mut desc = PropertyMap::new();
                     desc.insert("value".to_string(), val);
                     desc.insert(
                         "writable".to_string(),
@@ -5566,7 +5569,9 @@ fn make_reflect() -> JsValue {
         native(|args| {
             let target = require_object_arg(&args, 0, "Reflect.getPrototypeOf")?;
             match reflect_get_prototype_of(&target) {
-                Some(_) => Ok(JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())))),
+                Some(_) => Ok(JsValue::PlainObject(Rc::new(RefCell::new(
+                    PropertyMap::new(),
+                )))),
                 None => Ok(JsValue::Null),
             }
         }),
@@ -5832,7 +5837,11 @@ pub fn install_globals(globals: &mut HashMap<String, JsValue>) {
     // `globalThis` is a self-referential property of the global object.
     // The inner map is shared via `Rc` so that `globalThis.globalThis`
     // resolves back to the same object (configurable, writable, not enumerable).
-    let inner = Rc::new(RefCell::new(globals.clone()));
+    let mut inner_props = PropertyMap::new();
+    for (k, v) in globals.iter() {
+        inner_props.insert(k.clone(), v.clone());
+    }
+    let inner = Rc::new(RefCell::new(inner_props));
     inner
         .borrow_mut()
         .insert("globalThis".into(), JsValue::PlainObject(Rc::clone(&inner)));
@@ -6238,11 +6247,10 @@ mod tests {
     fn e2e_json_stringify_to_json_method() {
         use crate::builtins::json::json_stringify_js_value;
         use std::cell::RefCell;
-        use std::collections::HashMap;
         use std::rc::Rc;
 
         // Build a PlainObject with a toJSON method.
-        let mut inner: HashMap<String, JsValue> = HashMap::new();
+        let mut inner = PropertyMap::new();
         inner.insert("value".into(), JsValue::Smi(42));
         inner.insert(
             "toJSON".into(),
@@ -7131,9 +7139,9 @@ mod tests {
         if let JsValue::PlainObject(map) = obj {
             let assign = map.borrow().get("assign").cloned().unwrap();
             if let JsValue::NativeFunction(f) = assign {
-                let target_map: HashMap<String, JsValue> = HashMap::new();
+                let target_map = PropertyMap::new();
                 let target = JsValue::PlainObject(Rc::new(RefCell::new(target_map)));
-                let mut src_map: HashMap<String, JsValue> = HashMap::new();
+                let mut src_map = PropertyMap::new();
                 src_map.insert("b".into(), JsValue::Smi(2));
                 let source = JsValue::PlainObject(Rc::new(RefCell::new(src_map)));
                 let result = f(vec![target.clone(), source]).unwrap();
@@ -7158,13 +7166,13 @@ mod tests {
         if let JsValue::PlainObject(map) = obj {
             let assign = map.borrow().get("assign").cloned().unwrap();
             if let JsValue::NativeFunction(f) = assign {
-                let mut t: HashMap<String, JsValue> = HashMap::new();
+                let mut t = PropertyMap::new();
                 t.insert("a".into(), JsValue::Smi(1));
                 let target = JsValue::PlainObject(Rc::new(RefCell::new(t)));
-                let mut s1: HashMap<String, JsValue> = HashMap::new();
+                let mut s1 = PropertyMap::new();
                 s1.insert("b".into(), JsValue::Smi(2));
                 let src1 = JsValue::PlainObject(Rc::new(RefCell::new(s1)));
-                let mut s2: HashMap<String, JsValue> = HashMap::new();
+                let mut s2 = PropertyMap::new();
                 s2.insert("c".into(), JsValue::Smi(3));
                 let src2 = JsValue::PlainObject(Rc::new(RefCell::new(s2)));
                 let result = f(vec![target, src1, src2]).unwrap();

--- a/crates/stator_core/src/builtins/json.rs
+++ b/crates/stator_core/src/builtins/json.rs
@@ -1705,9 +1705,9 @@ mod tests {
 
     #[test]
     fn test_js_value_to_json_with_to_json_method() {
-        use std::collections::HashMap;
+        use crate::objects::property_map::PropertyMap;
 
-        let mut inner: HashMap<String, JsValue> = HashMap::new();
+        let mut inner = PropertyMap::new();
         inner.insert("value".into(), JsValue::Smi(42));
         inner.insert(
             "toJSON".into(),
@@ -1721,9 +1721,9 @@ mod tests {
 
     #[test]
     fn test_js_value_stringify_plain_object_with_replacer() {
-        use std::collections::HashMap;
+        use crate::objects::property_map::PropertyMap;
 
-        let mut map: HashMap<String, JsValue> = HashMap::new();
+        let mut map = PropertyMap::new();
         map.insert("a".into(), JsValue::Smi(1));
         map.insert("b".into(), JsValue::Smi(2));
         map.insert("c".into(), JsValue::Smi(3));

--- a/crates/stator_core/src/builtins/object.rs
+++ b/crates/stator_core/src/builtins/object.rs
@@ -1013,9 +1013,9 @@ mod tests {
 
     #[test]
     fn test_define_property_from_data_descriptor() {
-        use std::collections::HashMap;
+        use crate::objects::property_map::PropertyMap;
         let mut obj = JsObject::new();
-        let mut desc_map = HashMap::new();
+        let mut desc_map = PropertyMap::new();
         desc_map.insert("value".to_string(), JsValue::Smi(42));
         desc_map.insert("writable".to_string(), JsValue::Boolean(true));
         desc_map.insert("enumerable".to_string(), JsValue::Boolean(true));
@@ -1033,9 +1033,9 @@ mod tests {
 
     #[test]
     fn test_define_property_from_descriptor_non_writable() {
-        use std::collections::HashMap;
+        use crate::objects::property_map::PropertyMap;
         let mut obj = JsObject::new();
-        let mut desc_map = HashMap::new();
+        let mut desc_map = PropertyMap::new();
         desc_map.insert("value".to_string(), JsValue::Smi(7));
         desc_map.insert("writable".to_string(), JsValue::Boolean(false));
         let desc = JsValue::PlainObject(Rc::new(RefCell::new(desc_map)));
@@ -1050,9 +1050,9 @@ mod tests {
 
     #[test]
     fn test_define_property_from_descriptor_rejects_mixed() {
-        use std::collections::HashMap;
+        use crate::objects::property_map::PropertyMap;
         let mut obj = JsObject::new();
-        let mut desc_map = HashMap::new();
+        let mut desc_map = PropertyMap::new();
         desc_map.insert("value".to_string(), JsValue::Smi(1));
         desc_map.insert("get".to_string(), JsValue::Undefined);
         let desc = JsValue::PlainObject(Rc::new(RefCell::new(desc_map)));
@@ -1063,13 +1063,13 @@ mod tests {
 
     #[test]
     fn test_define_property_from_descriptor_non_configurable_redefine_rejected() {
-        use std::collections::HashMap;
+        use crate::objects::property_map::PropertyMap;
         let mut obj = JsObject::new();
         // First: define non-configurable property.
         obj.define_own_property("nc", JsValue::Smi(1), PropertyAttributes::WRITABLE)
             .unwrap();
         // Try to make it configurable.
-        let mut desc_map = HashMap::new();
+        let mut desc_map = PropertyMap::new();
         desc_map.insert("value".to_string(), JsValue::Smi(2));
         desc_map.insert("configurable".to_string(), JsValue::Boolean(true));
         let desc = JsValue::PlainObject(Rc::new(RefCell::new(desc_map)));
@@ -1082,22 +1082,22 @@ mod tests {
 
     #[test]
     fn test_define_properties_multiple_keys() {
-        use std::collections::HashMap;
+        use crate::objects::property_map::PropertyMap;
         let mut obj = JsObject::new();
 
-        let mut desc_a = HashMap::new();
+        let mut desc_a = PropertyMap::new();
         desc_a.insert("value".to_string(), JsValue::Smi(10));
         desc_a.insert("writable".to_string(), JsValue::Boolean(true));
         desc_a.insert("enumerable".to_string(), JsValue::Boolean(true));
         desc_a.insert("configurable".to_string(), JsValue::Boolean(true));
 
-        let mut desc_b = HashMap::new();
+        let mut desc_b = PropertyMap::new();
         desc_b.insert("value".to_string(), JsValue::Smi(20));
         desc_b.insert("writable".to_string(), JsValue::Boolean(false));
         desc_b.insert("enumerable".to_string(), JsValue::Boolean(false));
         desc_b.insert("configurable".to_string(), JsValue::Boolean(false));
 
-        let mut props_map = HashMap::new();
+        let mut props_map = PropertyMap::new();
         props_map.insert(
             "a".to_string(),
             JsValue::PlainObject(Rc::new(RefCell::new(desc_a))),
@@ -1196,9 +1196,9 @@ mod tests {
 
     #[test]
     fn test_non_enumerable_property_hidden_from_keys() {
-        use std::collections::HashMap;
+        use crate::objects::property_map::PropertyMap;
         let mut obj = JsObject::new();
-        let mut desc_map = HashMap::new();
+        let mut desc_map = PropertyMap::new();
         desc_map.insert("value".to_string(), JsValue::Smi(42));
         desc_map.insert("writable".to_string(), JsValue::Boolean(true));
         desc_map.insert("enumerable".to_string(), JsValue::Boolean(false));
@@ -1215,9 +1215,9 @@ mod tests {
 
     #[test]
     fn test_non_configurable_property_cannot_be_deleted() {
-        use std::collections::HashMap;
+        use crate::objects::property_map::PropertyMap;
         let mut obj = JsObject::new();
-        let mut desc_map = HashMap::new();
+        let mut desc_map = PropertyMap::new();
         desc_map.insert("value".to_string(), JsValue::Smi(1));
         desc_map.insert("configurable".to_string(), JsValue::Boolean(false));
         let desc = JsValue::PlainObject(Rc::new(RefCell::new(desc_map)));

--- a/crates/stator_core/src/builtins/regexp.rs
+++ b/crates/stator_core/src/builtins/regexp.rs
@@ -10,8 +10,9 @@
 //! the Rust-level API.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
+
+use crate::objects::property_map::PropertyMap;
 
 use crate::error::StatorResult;
 use crate::objects::regexp::{JsRegExp, RegExpFlags, SymbolMatchResult};
@@ -40,7 +41,7 @@ pub fn regexp_construct(args: &[JsValue]) -> StatorResult<JsValue> {
 /// ECMAScript `RegExp.prototype` properties and methods.
 pub fn wrap_regexp(re: JsRegExp) -> JsValue {
     let re = Rc::new(re);
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ── Read-only accessors ─────────────────────────────────────────────
     props.insert("source".into(), JsValue::String(re.pattern().to_string()));
@@ -207,7 +208,7 @@ pub fn wrap_regexp(re: JsRegExp) -> JsValue {
 /// * `groups` → named groups object (or `undefined`)
 /// * `indices` → `{ 0: [s,e], 1: [s,e], …, groups: {…} }` when `/d` flag
 fn match_to_js(m: &crate::objects::regexp::RegExpMatch) -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // [0] = full match
     props.insert("0".into(), JsValue::String(m.matched.clone()));
@@ -229,11 +230,10 @@ fn match_to_js(m: &crate::objects::regexp::RegExpMatch) -> JsValue {
     if m.named_groups.is_empty() {
         props.insert("groups".into(), JsValue::Undefined);
     } else {
-        let groups: HashMap<String, JsValue> = m
-            .named_groups
-            .iter()
-            .map(|(k, v)| (k.clone(), JsValue::String(v.clone())))
-            .collect();
+        let mut groups = PropertyMap::new();
+        for (k, v) in &m.named_groups {
+            groups.insert(k.clone(), JsValue::String(v.clone()));
+        }
         props.insert(
             "groups".into(),
             JsValue::PlainObject(Rc::new(RefCell::new(groups))),
@@ -242,7 +242,7 @@ fn match_to_js(m: &crate::objects::regexp::RegExpMatch) -> JsValue {
 
     // indices (only present when /d flag was used)
     if let Some(ref idx) = m.indices {
-        let mut idx_props: HashMap<String, JsValue> = HashMap::new();
+        let mut idx_props = PropertyMap::new();
         for (i, pair) in idx.pairs.iter().enumerate() {
             let val = match pair {
                 Some((s, e)) => JsValue::Array(Rc::new(vec![
@@ -254,19 +254,16 @@ fn match_to_js(m: &crate::objects::regexp::RegExpMatch) -> JsValue {
             idx_props.insert(i.to_string(), val);
         }
         if !idx.groups.is_empty() {
-            let g: HashMap<String, JsValue> = idx
-                .groups
-                .iter()
-                .map(|(k, (s, e))| {
-                    (
-                        k.clone(),
-                        JsValue::Array(Rc::new(vec![
-                            JsValue::Smi(*s as i32),
-                            JsValue::Smi(*e as i32),
-                        ])),
-                    )
-                })
-                .collect();
+            let mut g = PropertyMap::new();
+            for (k, (s, e)) in &idx.groups {
+                g.insert(
+                    k.clone(),
+                    JsValue::Array(Rc::new(vec![
+                        JsValue::Smi(*s as i32),
+                        JsValue::Smi(*e as i32),
+                    ])),
+                );
+            }
             idx_props.insert(
                 "groups".into(),
                 JsValue::PlainObject(Rc::new(RefCell::new(g))),

--- a/crates/stator_core/src/builtins/wasm.rs
+++ b/crates/stator_core/src/builtins/wasm.rs
@@ -43,10 +43,10 @@
 //! [WebAssembly JavaScript API]: https://webassembly.github.io/spec/js-api/
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::error::{StatorError, StatorResult};
+use crate::objects::property_map::PropertyMap;
 use crate::objects::value::{JsValue, NativeFn};
 use crate::wasm::{
     WasmEngine, WasmInstance, WasmModule, js_value_to_wasm_val, wasm_val_to_js_value,
@@ -123,7 +123,7 @@ fn compile_bytes(engine: &WasmEngine, bytes: &[u8]) -> StatorResult<WasmModule> 
 /// - `__wasm_bytes__` → `Array` of `Smi` (byte values 0–255)
 /// - `exports` → `Array` of export descriptor objects `{name, kind}`
 fn make_module_object(module: &WasmModule, bytes: Vec<u8>) -> JsValue {
-    let map: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let map: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
 
     // Tag the object type for later detection.
     map.borrow_mut().insert(
@@ -143,7 +143,7 @@ fn make_module_object(module: &WasmModule, bytes: Vec<u8>) -> JsValue {
         .inner()
         .exports()
         .map(|exp| {
-            let desc: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+            let desc: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
             desc.borrow_mut()
                 .insert("name".to_string(), JsValue::String(exp.name().to_string()));
             let kind = match exp.ty() {
@@ -237,7 +237,7 @@ fn make_instance_object(module: &WasmModule, engine: &WasmEngine) -> StatorResul
         Rc::new(RefCell::new(WasmInstance::new(engine, module)?));
 
     // Build the exports map with one NativeFunction per exported function.
-    let exports_map: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let exports_map: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
     for (name, is_func) in export_info {
         if is_func {
             let inst_ref = Rc::clone(&instance_rc);
@@ -263,7 +263,7 @@ fn make_instance_object(module: &WasmModule, engine: &WasmEngine) -> StatorResul
         // Non-function exports (memory, table, global) are not yet exposed.
     }
 
-    let instance_map: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let instance_map: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
     instance_map.borrow_mut().insert(
         "__wasm_type__".to_string(),
         JsValue::String("WebAssembly.Instance".to_string()),
@@ -385,7 +385,7 @@ pub fn wasm_instantiate(args: Vec<JsValue>) -> StatorResult<JsValue> {
         let module_obj = make_module_object(&module, bytes);
         let instance_obj = make_instance_object(&module, &engine)?;
 
-        let result: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+        let result: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
         result.borrow_mut().insert("module".to_string(), module_obj);
         result
             .borrow_mut()
@@ -462,13 +462,13 @@ pub fn wasm_instance_ctor(args: Vec<JsValue>) -> StatorResult<JsValue> {
 /// # Examples
 ///
 /// ```
-/// use std::collections::HashMap;
+/// use stator_core::objects::property_map::PropertyMap;
 /// use std::cell::RefCell;
 /// use std::rc::Rc;
 /// use stator_core::builtins::wasm::wasm_memory_ctor;
 /// use stator_core::objects::value::JsValue;
 ///
-/// let desc: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+/// let desc: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
 /// desc.borrow_mut().insert("initial".to_string(), JsValue::Smi(1));
 /// let mem = wasm_memory_ctor(vec![JsValue::PlainObject(desc)]).unwrap();
 /// assert!(matches!(mem, JsValue::PlainObject(_)));
@@ -519,7 +519,7 @@ pub fn wasm_memory_ctor(args: Vec<JsValue>) -> StatorResult<JsValue> {
         }
     });
 
-    let memory_map: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let memory_map: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
     memory_map.borrow_mut().insert(
         "__wasm_type__".to_string(),
         JsValue::String("WebAssembly.Memory".to_string()),
@@ -590,7 +590,7 @@ pub fn wasm_table_ctor(args: Vec<JsValue>) -> StatorResult<JsValue> {
 
     // `table_map` is built after the closures but shared with `grow_fn` so that
     // grow() can update the `length` property to reflect the new size.
-    let table_map: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let table_map: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
     let table_map_for_grow = Rc::clone(&table_map);
 
     let get_fn: NativeFn = Rc::new(move |args: Vec<JsValue>| {
@@ -698,13 +698,13 @@ pub fn wasm_table_ctor(args: Vec<JsValue>) -> StatorResult<JsValue> {
 /// # Examples
 ///
 /// ```
-/// use std::collections::HashMap;
+/// use stator_core::objects::property_map::PropertyMap;
 /// use std::cell::RefCell;
 /// use std::rc::Rc;
 /// use stator_core::builtins::wasm::wasm_global_ctor;
 /// use stator_core::objects::value::JsValue;
 ///
-/// let desc: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+/// let desc: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
 /// desc.borrow_mut().insert("value".to_string(), JsValue::String("i32".to_string()));
 /// desc.borrow_mut().insert("mutable".to_string(), JsValue::Boolean(true));
 /// let global = wasm_global_ctor(vec![JsValue::PlainObject(desc), JsValue::Smi(42)]).unwrap();
@@ -739,7 +739,7 @@ pub fn wasm_global_ctor(args: Vec<JsValue>) -> StatorResult<JsValue> {
     let valueof_fn: NativeFn =
         Rc::new(move |_args: Vec<JsValue>| Ok(current_for_valueof.borrow().clone()));
 
-    let global_map: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let global_map: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
     global_map.borrow_mut().insert(
         "__wasm_type__".to_string(),
         JsValue::String("WebAssembly.Global".to_string()),
@@ -786,7 +786,7 @@ pub fn wasm_global_ctor(args: Vec<JsValue>) -> StatorResult<JsValue> {
 /// assert!(matches!(wasm_obj, JsValue::PlainObject(_)));
 /// ```
 pub fn make_webassembly_object() -> JsValue {
-    let map: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let map: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
 
     map.borrow_mut().insert(
         "validate".to_string(),
@@ -831,10 +831,10 @@ pub fn make_webassembly_object() -> JsValue {
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;
-    use std::collections::HashMap;
     use std::rc::Rc;
 
     use super::*;
+    use crate::objects::property_map::PropertyMap;
 
     // ── WAT helpers ──────────────────────────────────────────────────────────
 
@@ -883,7 +883,7 @@ mod tests {
 
     /// Helper: plain descriptor object `{key: value}`.
     fn descriptor(pairs: &[(&str, JsValue)]) -> JsValue {
-        let map: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+        let map: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
         for (k, v) in pairs {
             map.borrow_mut().insert(k.to_string(), v.clone());
         }

--- a/crates/stator_core/src/dom/mod.rs
+++ b/crates/stator_core/src/dom/mod.rs
@@ -16,10 +16,10 @@
 //!   can release the backing DOM node when the JS wrapper is collected.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::ffi::c_void;
 use std::rc::Rc;
 
+use crate::objects::property_map::PropertyMap;
 use crate::objects::value::JsValue;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -387,7 +387,7 @@ pub const MAX_INTERNAL_FIELDS: usize = 16;
 pub struct DomObjectWrap {
     /// Own JS properties (for the rare case where the embedder stores values
     /// directly on the wrapper rather than going through interceptors).
-    properties: Rc<RefCell<HashMap<String, JsValue>>>,
+    properties: Rc<RefCell<PropertyMap>>,
     /// Opaque embedder pointers (e.g. `blink::Element*`).
     internal_fields: Vec<*mut c_void>,
     /// Optional named-property interceptor configuration.
@@ -415,7 +415,7 @@ impl DomObjectWrap {
             "field_count ({field_count}) exceeds MAX_INTERNAL_FIELDS ({MAX_INTERNAL_FIELDS})"
         );
         Self {
-            properties: Rc::new(RefCell::new(HashMap::new())),
+            properties: Rc::new(RefCell::new(PropertyMap::new())),
             internal_fields: vec![std::ptr::null_mut(); field_count],
             named_handler: None,
             indexed_handler: None,

--- a/crates/stator_core/src/ffi/mod.rs
+++ b/crates/stator_core/src/ffi/mod.rs
@@ -40,6 +40,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::error::{StatorError, StatorResult};
+use crate::objects::property_map::PropertyMap;
 use crate::objects::value::JsValue;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -201,7 +202,7 @@ impl V8Object {
     /// Create a new, empty JavaScript object.
     pub fn new() -> Self {
         Self {
-            inner: JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new()))),
+            inner: JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new()))),
         }
     }
 
@@ -1033,7 +1034,10 @@ impl V8ObjectTemplate {
     /// Create a new [`JsValue::PlainObject`] instance populated with the
     /// predefined properties from this template.
     pub fn new_instance(&self) -> JsValue {
-        let map: HashMap<String, JsValue> = self.properties.clone();
+        let mut map = PropertyMap::new();
+        for (k, v) in &self.properties {
+            map.insert(k.clone(), v.clone());
+        }
         JsValue::PlainObject(Rc::new(RefCell::new(map)))
     }
 }
@@ -1224,7 +1228,7 @@ mod tests {
 
     #[test]
     fn test_v8object_from_jsvalue() {
-        let map = Rc::new(RefCell::new(HashMap::new()));
+        let map = Rc::new(RefCell::new(PropertyMap::new()));
         map.borrow_mut().insert("key".to_string(), JsValue::Smi(10));
         let val = JsValue::PlainObject(map);
         let obj = V8Object::from(val);
@@ -1605,7 +1609,7 @@ mod tests {
 
     #[test]
     fn test_v8value_try_into_object() {
-        let obj_val = JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
+        let obj_val = JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new())));
         let v = V8Value::new(obj_val);
         assert!(v.is_object());
         let obj = v.try_into_object().unwrap();
@@ -1744,7 +1748,9 @@ mod tests {
     #[test]
     fn test_trycatch_set_caught_object() {
         let mut tc = V8TryCatch::new();
-        tc.set_caught(JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new()))));
+        tc.set_caught(JsValue::PlainObject(Rc::new(RefCell::new(
+            PropertyMap::new(),
+        ))));
         assert!(tc.has_caught());
         assert_eq!(tc.message(), Some("[object]"));
     }

--- a/crates/stator_core/src/inspector/heap_snapshot.rs
+++ b/crates/stator_core/src/inspector/heap_snapshot.rs
@@ -506,6 +506,7 @@ mod tests {
     use std::rc::Rc;
 
     use super::*;
+    use crate::objects::property_map::PropertyMap;
     use crate::objects::value::JsValue;
 
     // ── HeapSnapshotBuilder::build ────────────────────────────────────────────
@@ -550,7 +551,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_plain_object_edges() {
-        let mut inner = HashMap::new();
+        let mut inner = PropertyMap::new();
         inner.insert("a".to_string(), JsValue::Smi(1));
         inner.insert("b".to_string(), JsValue::Smi(2));
         let obj = JsValue::PlainObject(Rc::new(RefCell::new(inner)));

--- a/crates/stator_core/src/interpreter/dispatch.rs
+++ b/crates/stator_core/src/interpreter/dispatch.rs
@@ -8,8 +8,9 @@
 #![allow(clippy::too_many_lines)]
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
+
+use crate::objects::property_map::PropertyMap;
 
 use super::{
     ACTIVE_DEBUGGER, Interpreter, InterpreterFrame, MAGLEV_OSR_LOOP_THRESHOLD, OSR_LOOP_THRESHOLD,
@@ -1483,8 +1484,7 @@ fn handle_construct(
             // [[Construct]]: create a fresh object for `this`,
             // wire its __proto__ to the constructor's prototype,
             // then run the constructor body with `this` bound.
-            let this_obj: Rc<RefCell<HashMap<String, JsValue>>> =
-                Rc::new(RefCell::new(HashMap::new()));
+            let this_obj: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
             if !matches!(ctor_proto, JsValue::Undefined) {
                 this_obj
                     .borrow_mut()
@@ -1881,6 +1881,12 @@ fn handle_sta_named_property(
             let _ = proxy_set(&mut p.borrow_mut(), &prop_name, val)?;
         }
         JsValue::PlainObject(ref map) => {
+            let pm = map.borrow();
+            // Existing non-writable property: silently ignore (sloppy mode).
+            if pm.contains_key(&prop_name) && !pm.is_writable(&prop_name) {
+                return Ok(DispatchAction::Continue);
+            }
+            drop(pm);
             map.borrow_mut().insert(prop_name, val);
         }
         JsValue::Function(ref ba) => {
@@ -2288,7 +2294,7 @@ fn handle_create_empty_object_literal(
     ctx: &mut DispatchContext,
     _instr: &Instruction,
 ) -> StatorResult<DispatchAction> {
-    ctx.frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
+    ctx.frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new())));
     Ok(DispatchAction::Continue)
 }
 
@@ -2297,7 +2303,7 @@ fn handle_create_empty_array_literal(
     _instr: &Instruction,
 ) -> StatorResult<DispatchAction> {
     // operands[0] is a FeedbackSlot, ignored at runtime.
-    let mut map = HashMap::new();
+    let mut map = PropertyMap::new();
     map.insert("length".to_string(), JsValue::Smi(0));
     ctx.frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
     Ok(DispatchAction::Continue)
@@ -2308,7 +2314,7 @@ fn handle_create_array_literal(
     _instr: &Instruction,
 ) -> StatorResult<DispatchAction> {
     // operands: [ConstantPoolIdx, FeedbackSlot, Flag]
-    let mut map = HashMap::new();
+    let mut map = PropertyMap::new();
     map.insert("length".to_string(), JsValue::Smi(0));
     ctx.frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
     Ok(DispatchAction::Continue)
@@ -2334,7 +2340,7 @@ fn handle_create_array_from_iterable(
         }
         _ => vec![],
     };
-    let mut map = HashMap::new();
+    let mut map = PropertyMap::new();
     for (i, v) in items.iter().enumerate() {
         map.insert(i.to_string(), v.clone());
     }
@@ -2348,7 +2354,7 @@ fn handle_create_object_literal(
     _instr: &Instruction,
 ) -> StatorResult<DispatchAction> {
     // operands: [ConstantPoolIdx, FeedbackSlot, Flag]
-    ctx.frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
+    ctx.frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new())));
     Ok(DispatchAction::Continue)
 }
 
@@ -2387,7 +2393,7 @@ fn handle_create_reg_exp_literal(
     if flags_val & 0x20 != 0 {
         flags_str.push('y');
     }
-    let mut map = HashMap::new();
+    let mut map = PropertyMap::new();
     map.insert("source".to_string(), JsValue::String(pattern.clone()));
     map.insert("flags".to_string(), JsValue::String(flags_str.clone()));
     // toString() representation: /pattern/flags
@@ -2601,7 +2607,7 @@ fn handle_for_in_enumerate(
     let keys: Vec<JsValue> = match &obj {
         JsValue::PlainObject(map) => map
             .borrow()
-            .keys()
+            .enumerable_keys()
             .map(|k| JsValue::String(k.clone()))
             .collect(),
         JsValue::Array(items) => {
@@ -2721,7 +2727,14 @@ fn handle_delete_property_sloppy(
     let removed = if let JsValue::Proxy(ref p) = obj {
         proxy_delete_property(&mut p.borrow_mut(), &key).unwrap_or(false)
     } else if let JsValue::PlainObject(ref map) = obj {
-        map.borrow_mut().remove(&key).is_some()
+        let pm = map.borrow();
+        if pm.contains_key(&key) && !pm.is_configurable(&key) {
+            // Non-configurable: silently fail in sloppy mode.
+            false
+        } else {
+            drop(pm);
+            map.borrow_mut().remove(&key).is_some()
+        }
     } else {
         false
     };
@@ -2741,6 +2754,13 @@ fn handle_delete_property_strict(
     if let JsValue::Proxy(ref p) = obj {
         proxy_delete_property(&mut p.borrow_mut(), &key)?;
     } else if let JsValue::PlainObject(ref map) = obj {
+        let pm = map.borrow();
+        if pm.contains_key(&key) && !pm.is_configurable(&key) {
+            return Err(StatorError::TypeError(format!(
+                "Cannot delete property '{key}' of object"
+            )));
+        }
+        drop(pm);
         map.borrow_mut().remove(&key);
     }
     ctx.frame.accumulator = JsValue::Boolean(true);
@@ -2772,15 +2792,11 @@ fn handle_create_mapped_arguments(
         .get(..param_count)
         .unwrap_or(&[])
         .to_vec();
-    let map: HashMap<String, JsValue> = args
-        .iter()
-        .enumerate()
-        .map(|(i, v)| (i.to_string(), v.clone()))
-        .chain(std::iter::once((
-            "length".to_string(),
-            JsValue::Smi(args.len() as i32),
-        )))
-        .collect();
+    let mut map = PropertyMap::new();
+    for (i, v) in args.iter().enumerate() {
+        map.insert(i.to_string(), v.clone());
+    }
+    map.insert("length".to_string(), JsValue::Smi(args.len() as i32));
     ctx.frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
     Ok(DispatchAction::Continue)
 }
@@ -2796,15 +2812,11 @@ fn handle_create_unmapped_arguments(
         .get(..param_count)
         .unwrap_or(&[])
         .to_vec();
-    let map: HashMap<String, JsValue> = args
-        .iter()
-        .enumerate()
-        .map(|(i, v)| (i.to_string(), v.clone()))
-        .chain(std::iter::once((
-            "length".to_string(),
-            JsValue::Smi(args.len() as i32),
-        )))
-        .collect();
+    let mut map = PropertyMap::new();
+    for (i, v) in args.iter().enumerate() {
+        map.insert(i.to_string(), v.clone());
+    }
+    map.insert("length".to_string(), JsValue::Smi(args.len() as i32));
     ctx.frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
     Ok(DispatchAction::Continue)
 }
@@ -2926,7 +2938,7 @@ fn handle_call_runtime(
         // Build a namespace object with a default export
         // equal to the specifier string (stub for now — a
         // full implementation would resolve a module).
-        let ns = HashMap::new();
+        let ns = PropertyMap::new();
         let ns_val = JsValue::PlainObject(Rc::new(RefCell::new(ns)));
 
         let queue = MicrotaskQueue::new();
@@ -3552,10 +3564,10 @@ fn handle_create_object_from_iterable(
     _instr: &Instruction,
 ) -> StatorResult<DispatchAction> {
     let iterable = ctx.frame.accumulator.clone();
-    let map: HashMap<String, JsValue> = match &iterable {
+    let map: PropertyMap = match &iterable {
         JsValue::PlainObject(obj) => obj.borrow().clone(),
         JsValue::Array(arr) => {
-            let mut m = HashMap::new();
+            let mut m = PropertyMap::new();
             for (i, v) in arr.iter().enumerate() {
                 m.insert(i.to_string(), v.clone());
             }
@@ -3563,7 +3575,7 @@ fn handle_create_object_from_iterable(
             m
         }
         JsValue::Iterator(iter) => {
-            let mut m = HashMap::new();
+            let mut m = PropertyMap::new();
             let mut idx = 0usize;
             loop {
                 let mut it = iter.borrow_mut();
@@ -3578,7 +3590,7 @@ fn handle_create_object_from_iterable(
             m.insert("length".to_string(), JsValue::Smi(idx as i32));
             m
         }
-        _ => HashMap::new(),
+        _ => PropertyMap::new(),
     };
     ctx.frame.accumulator = JsValue::PlainObject(Rc::new(RefCell::new(map)));
     Ok(DispatchAction::Continue)

--- a/crates/stator_core/src/interpreter/mod.rs
+++ b/crates/stator_core/src/interpreter/mod.rs
@@ -183,6 +183,7 @@ use crate::bytecode::bytecode_array::{MaglevJitCodeCache, TurbofanJitCodeCache};
 use crate::bytecode::bytecodes::decode_with_byte_offsets;
 use crate::error::{StatorError, StatorResult};
 use crate::inspector::debugger::Debugger;
+use crate::objects::property_map::PropertyMap;
 use crate::objects::value::{JsContext, JsValue};
 
 // Re-export generator types and bring them into scope so external code can
@@ -1190,12 +1191,9 @@ impl Interpreter {
 
 /// Create a `{ value, done }` iterator result object.
 fn make_iterator_result(value: JsValue, done: bool) -> JsValue {
-    let map: HashMap<String, JsValue> = [
-        ("value".to_string(), value),
-        ("done".to_string(), JsValue::Boolean(done)),
-    ]
-    .into_iter()
-    .collect();
+    let mut map = PropertyMap::new();
+    map.insert("value".to_string(), value);
+    map.insert("done".to_string(), JsValue::Boolean(done));
     JsValue::PlainObject(Rc::new(RefCell::new(map)))
 }
 
@@ -1313,7 +1311,7 @@ pub(super) fn constant_to_value(entry: &ConstantPoolEntry) -> JsValue {
 /// property, and a `raw` sub-object with the same layout holding the raw
 /// (un-escaped) strings.
 fn build_template_object(cooked: &[Option<String>], raw: &[String]) -> JsValue {
-    let mut map = HashMap::new();
+    let mut map = PropertyMap::new();
     for (i, c) in cooked.iter().enumerate() {
         let val = match c {
             Some(s) => JsValue::String(s.clone()),
@@ -1323,7 +1321,7 @@ fn build_template_object(cooked: &[Option<String>], raw: &[String]) -> JsValue {
     }
     map.insert("length".to_string(), JsValue::Smi(cooked.len() as i32));
 
-    let mut raw_map = HashMap::new();
+    let mut raw_map = PropertyMap::new();
     for (i, r) in raw.iter().enumerate() {
         raw_map.insert(i.to_string(), JsValue::String(r.clone()));
     }
@@ -1957,6 +1955,13 @@ pub(super) fn keyed_store(obj: &JsValue, key: &JsValue, value: JsValue) -> Stato
         }
         JsValue::PlainObject(map) => {
             let prop_name = to_property_key(key)?;
+            // Existing non-writable property: silently ignore (sloppy mode).
+            {
+                let pm = map.borrow();
+                if pm.contains_key(&prop_name) && !pm.is_writable(&prop_name) {
+                    return Ok(());
+                }
+            }
             map.borrow_mut().insert(prop_name, value);
             // If this is an array-like PlainObject, update "length".
             if let Some(idx) = to_array_index(key) {
@@ -1982,9 +1987,7 @@ pub(super) fn keyed_store(obj: &JsValue, key: &JsValue, value: JsValue) -> Stato
 
 /// Extract array elements from a PlainObject that represents an array-like
 /// value (has a `"length"` property and numeric-string keys).
-pub(super) fn plain_object_to_array_items(
-    map: &Rc<RefCell<HashMap<String, JsValue>>>,
-) -> Vec<JsValue> {
+pub(super) fn plain_object_to_array_items(map: &Rc<RefCell<PropertyMap>>) -> Vec<JsValue> {
     let borrow = map.borrow();
     let len = match borrow.get("length") {
         Some(JsValue::Smi(n)) => *n as usize,
@@ -5241,8 +5244,10 @@ mod tests {
 
     /// Helper: create a PlainObject from key-value pairs.
     fn make_plain_object(pairs: Vec<(&str, JsValue)>) -> JsValue {
-        let map: HashMap<String, JsValue> =
-            pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
+        let mut map = PropertyMap::new();
+        for (k, v) in pairs {
+            map.insert(k.to_string(), v);
+        }
         JsValue::PlainObject(Rc::new(RefCell::new(map)))
     }
 
@@ -5582,16 +5587,16 @@ mod tests {
         // Build: constructor.prototype = proto_obj
         //        instance.__proto__   = proto_obj
         // TestInstanceOf should find the match.
-        let proto = Rc::new(RefCell::new(HashMap::new()));
+        let proto = Rc::new(RefCell::new(PropertyMap::new()));
         proto
             .borrow_mut()
             .insert("kind".to_string(), JsValue::String("proto".to_string()));
 
-        let mut ctor_map = HashMap::new();
+        let mut ctor_map = PropertyMap::new();
         ctor_map.insert("prototype".to_string(), JsValue::PlainObject(proto.clone()));
         let constructor = JsValue::PlainObject(Rc::new(RefCell::new(ctor_map)));
 
-        let mut inst_map = HashMap::new();
+        let mut inst_map = PropertyMap::new();
         inst_map.insert("__proto__".to_string(), JsValue::PlainObject(proto.clone()));
         let instance = JsValue::PlainObject(Rc::new(RefCell::new(inst_map)));
 
@@ -5611,14 +5616,14 @@ mod tests {
     #[test]
     fn test_test_instance_of_no_match() {
         // Two different prototypes — should return false.
-        let proto_a = Rc::new(RefCell::new(HashMap::new()));
-        let proto_b = Rc::new(RefCell::new(HashMap::new()));
+        let proto_a = Rc::new(RefCell::new(PropertyMap::new()));
+        let proto_b = Rc::new(RefCell::new(PropertyMap::new()));
 
-        let mut ctor_map = HashMap::new();
+        let mut ctor_map = PropertyMap::new();
         ctor_map.insert("prototype".to_string(), JsValue::PlainObject(proto_a));
         let constructor = JsValue::PlainObject(Rc::new(RefCell::new(ctor_map)));
 
-        let mut inst_map = HashMap::new();
+        let mut inst_map = PropertyMap::new();
         inst_map.insert("__proto__".to_string(), JsValue::PlainObject(proto_b));
         let instance = JsValue::PlainObject(Rc::new(RefCell::new(inst_map)));
 
@@ -5639,7 +5644,7 @@ mod tests {
     #[test]
     fn test_test_in_plain_object_existing_key() {
         // "x" in { x: 1 } → true
-        let mut map = HashMap::new();
+        let mut map = PropertyMap::new();
         map.insert("x".to_string(), JsValue::Smi(1));
         let obj = JsValue::PlainObject(Rc::new(RefCell::new(map)));
 
@@ -5658,7 +5663,7 @@ mod tests {
     #[test]
     fn test_test_in_plain_object_missing_key() {
         // "y" in { x: 1 } → false
-        let mut map = HashMap::new();
+        let mut map = PropertyMap::new();
         map.insert("x".to_string(), JsValue::Smi(1));
         let obj = JsValue::PlainObject(Rc::new(RefCell::new(map)));
 
@@ -6348,7 +6353,7 @@ mod tests {
     fn test_plain_object_to_array_items() {
         // Build a PlainObject with numeric keys and verify
         // plain_object_to_array_items extracts elements correctly.
-        let map: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+        let map: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
         {
             let mut borrow = map.borrow_mut();
             borrow.insert("0".to_string(), JsValue::Smi(10));

--- a/crates/stator_core/src/objects/mod.rs
+++ b/crates/stator_core/src/objects/mod.rs
@@ -17,6 +17,9 @@ pub mod nan_boxing;
 /// ECMAScript §6.2.6 Property Descriptor specification type with data,
 /// accessor, and generic variants plus validation logic.
 pub mod property_descriptor;
+/// A [`HashMap`]-like property store that pairs each value with
+/// [`map::PropertyAttributes`] flags for ECMAScript attribute enforcement.
+pub mod property_map;
 /// JavaScript `RegExp` object with ECMAScript flag and built-in method support.
 pub mod regexp;
 /// V8-style hidden-class (shape) system with transition trees and descriptor

--- a/crates/stator_core/src/objects/property_descriptor.rs
+++ b/crates/stator_core/src/objects/property_descriptor.rs
@@ -14,11 +14,11 @@
 //! `Object.defineProperty` and `Object.getOwnPropertyDescriptor`).
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::error::{StatorError, StatorResult};
 use crate::objects::map::PropertyAttributes;
+use crate::objects::property_map::PropertyMap;
 use crate::objects::value::JsValue;
 
 /// ECMAScript §6.2.6 Property Descriptor.
@@ -220,7 +220,7 @@ impl FullPropertyDescriptor {
     /// The returned [`JsValue::PlainObject`] has the appropriate keys
     /// (`value`, `writable`, `get`, `set`, `enumerable`, `configurable`).
     pub fn to_object(&self) -> JsValue {
-        let mut map = HashMap::new();
+        let mut map = PropertyMap::new();
         match self {
             Self::Data {
                 value,
@@ -506,7 +506,7 @@ mod tests {
 
     #[test]
     fn test_from_object_rejects_mixed_data_accessor() {
-        let mut map = HashMap::new();
+        let mut map = PropertyMap::new();
         map.insert("value".to_string(), JsValue::Smi(1));
         map.insert("get".to_string(), JsValue::Undefined);
         let obj = JsValue::PlainObject(Rc::new(RefCell::new(map)));
@@ -516,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_from_object_empty_yields_generic() {
-        let map = HashMap::new();
+        let map = PropertyMap::new();
         let obj = JsValue::PlainObject(Rc::new(RefCell::new(map)));
         let desc = FullPropertyDescriptor::from_object(&obj).unwrap();
         assert!(desc.is_generic());

--- a/crates/stator_core/src/objects/property_map.rs
+++ b/crates/stator_core/src/objects/property_map.rs
@@ -1,0 +1,306 @@
+//! A property map that stores ECMAScript property values alongside their
+//! attribute flags (`[[Writable]]`, `[[Enumerable]]`, `[[Configurable]]`).
+//!
+//! [`PropertyMap`] is the backing store for [`JsValue::PlainObject`] and
+//! provides a HashMap-like API that transparently attaches
+//! [`PropertyAttributes`] to every entry.  Newly inserted properties default
+//! to `WRITABLE | ENUMERABLE | CONFIGURABLE` (the ECMAScript default for
+//! ordinary user-created data properties).
+
+use std::collections::HashMap;
+
+use crate::objects::map::PropertyAttributes;
+use crate::objects::value::JsValue;
+
+/// Default attributes for properties created by ordinary JS assignment:
+/// writable, enumerable, and configurable.
+const DEFAULT_ATTRS: PropertyAttributes = PropertyAttributes::from_bits_truncate(
+    PropertyAttributes::WRITABLE.bits()
+        | PropertyAttributes::ENUMERABLE.bits()
+        | PropertyAttributes::CONFIGURABLE.bits(),
+);
+
+/// A map of named properties with ECMAScript attribute flags.
+///
+/// Each entry carries a [`JsValue`] and its [`PropertyAttributes`].
+/// The API mirrors `HashMap<String, JsValue>` for ease of migration while
+/// adding attribute-aware accessors.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PropertyMap {
+    entries: HashMap<String, (JsValue, PropertyAttributes)>,
+}
+
+impl PropertyMap {
+    /// Creates an empty property map.
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Creates a property map pre-allocated for `capacity` entries.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::with_capacity(capacity),
+        }
+    }
+
+    // ── HashMap-compatible API ────────────────────────────────────────────
+
+    /// Returns the value for `key`, ignoring attributes.
+    pub fn get(&self, key: &str) -> Option<&JsValue> {
+        self.entries.get(key).map(|(v, _)| v)
+    }
+
+    /// Returns a clone of the value for `key`, ignoring attributes.
+    pub fn get_cloned(&self, key: &str) -> Option<JsValue> {
+        self.entries.get(key).map(|(v, _)| v.clone())
+    }
+
+    /// Returns `true` if the map contains an entry for `key`.
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.entries.contains_key(key)
+    }
+
+    /// Inserts a property with default attributes (writable, enumerable,
+    /// configurable).  If the key already exists the value is replaced but
+    /// the existing attributes are preserved.
+    pub fn insert(&mut self, key: String, value: JsValue) {
+        let attrs = self
+            .entries
+            .get(&key)
+            .map(|(_, a)| *a)
+            .unwrap_or(DEFAULT_ATTRS);
+        self.entries.insert(key, (value, attrs));
+    }
+
+    /// Removes the entry for `key`, returning the old value (if any).
+    pub fn remove(&mut self, key: &str) -> Option<JsValue> {
+        self.entries.remove(key).map(|(v, _)| v)
+    }
+
+    /// Returns an iterator over the property keys.
+    pub fn keys(&self) -> impl Iterator<Item = &String> {
+        self.entries.keys()
+    }
+
+    /// Returns an iterator over `(key, value)` pairs, ignoring attributes.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &JsValue)> {
+        self.entries.iter().map(|(k, (v, _))| (k, v))
+    }
+
+    /// Returns the number of entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` if the map contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    // ── Attribute-aware API ───────────────────────────────────────────────
+
+    /// Returns the value and attribute flags for `key`.
+    pub fn get_with_attrs(&self, key: &str) -> Option<(&JsValue, PropertyAttributes)> {
+        self.entries.get(key).map(|(v, a)| (v, *a))
+    }
+
+    /// Inserts a property with explicit attribute flags.
+    pub fn insert_with_attrs(&mut self, key: String, value: JsValue, attrs: PropertyAttributes) {
+        self.entries.insert(key, (value, attrs));
+    }
+
+    /// Updates the attribute flags for an existing property.
+    /// Returns `true` if the property existed and was updated.
+    pub fn set_attrs(&mut self, key: &str, attrs: PropertyAttributes) -> bool {
+        if let Some(entry) = self.entries.get_mut(key) {
+            entry.1 = attrs;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the attribute flags for `key`, or `None` if absent.
+    pub fn attrs(&self, key: &str) -> Option<PropertyAttributes> {
+        self.entries.get(key).map(|(_, a)| *a)
+    }
+
+    /// Returns `true` if the property exists and is writable.
+    pub fn is_writable(&self, key: &str) -> bool {
+        self.entries
+            .get(key)
+            .map(|(_, a)| a.contains(PropertyAttributes::WRITABLE))
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` if the property exists and is configurable.
+    pub fn is_configurable(&self, key: &str) -> bool {
+        self.entries
+            .get(key)
+            .map(|(_, a)| a.contains(PropertyAttributes::CONFIGURABLE))
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` if the property exists and is enumerable.
+    pub fn is_enumerable(&self, key: &str) -> bool {
+        self.entries
+            .get(key)
+            .map(|(_, a)| a.contains(PropertyAttributes::ENUMERABLE))
+            .unwrap_or(false)
+    }
+
+    /// Returns an iterator over only the enumerable property keys.
+    pub fn enumerable_keys(&self) -> impl Iterator<Item = &String> {
+        self.entries
+            .iter()
+            .filter(|(_, (_, a))| a.contains(PropertyAttributes::ENUMERABLE))
+            .map(|(k, _)| k)
+    }
+
+    /// Returns an iterator over `(key, value, attrs)` triples.
+    pub fn iter_with_attrs(&self) -> impl Iterator<Item = (&String, &JsValue, PropertyAttributes)> {
+        self.entries.iter().map(|(k, (v, a))| (k, v, *a))
+    }
+}
+
+impl Default for PropertyMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_get_default_attrs() {
+        let mut pm = PropertyMap::new();
+        pm.insert("x".to_string(), JsValue::Smi(42));
+        assert_eq!(pm.get("x"), Some(&JsValue::Smi(42)));
+        let attrs = pm.attrs("x").unwrap();
+        assert!(attrs.contains(PropertyAttributes::WRITABLE));
+        assert!(attrs.contains(PropertyAttributes::ENUMERABLE));
+        assert!(attrs.contains(PropertyAttributes::CONFIGURABLE));
+    }
+
+    #[test]
+    fn test_insert_with_attrs() {
+        let mut pm = PropertyMap::new();
+        pm.insert_with_attrs(
+            "ro".to_string(),
+            JsValue::Smi(1),
+            PropertyAttributes::empty(),
+        );
+        assert!(!pm.is_writable("ro"));
+        assert!(!pm.is_enumerable("ro"));
+        assert!(!pm.is_configurable("ro"));
+    }
+
+    #[test]
+    fn test_insert_preserves_existing_attrs() {
+        let mut pm = PropertyMap::new();
+        pm.insert_with_attrs(
+            "p".to_string(),
+            JsValue::Smi(1),
+            PropertyAttributes::ENUMERABLE,
+        );
+        // Re-insert with default insert — should preserve ENUMERABLE-only.
+        pm.insert("p".to_string(), JsValue::Smi(2));
+        assert_eq!(pm.get("p"), Some(&JsValue::Smi(2)));
+        let attrs = pm.attrs("p").unwrap();
+        assert_eq!(attrs, PropertyAttributes::ENUMERABLE);
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut pm = PropertyMap::new();
+        pm.insert("a".to_string(), JsValue::Boolean(true));
+        assert!(pm.contains_key("a"));
+        let removed = pm.remove("a");
+        assert_eq!(removed, Some(JsValue::Boolean(true)));
+        assert!(!pm.contains_key("a"));
+    }
+
+    #[test]
+    fn test_enumerable_keys() {
+        let mut pm = PropertyMap::new();
+        pm.insert("visible".to_string(), JsValue::Smi(1));
+        pm.insert_with_attrs(
+            "hidden".to_string(),
+            JsValue::Smi(2),
+            PropertyAttributes::WRITABLE,
+        );
+        let enum_keys: Vec<&String> = pm.enumerable_keys().collect();
+        assert!(enum_keys.contains(&&"visible".to_string()));
+        assert!(!enum_keys.contains(&&"hidden".to_string()));
+    }
+
+    #[test]
+    fn test_len_and_is_empty() {
+        let mut pm = PropertyMap::new();
+        assert!(pm.is_empty());
+        assert_eq!(pm.len(), 0);
+        pm.insert("k".to_string(), JsValue::Null);
+        assert!(!pm.is_empty());
+        assert_eq!(pm.len(), 1);
+    }
+
+    #[test]
+    fn test_set_attrs() {
+        let mut pm = PropertyMap::new();
+        pm.insert("p".to_string(), JsValue::Smi(1));
+        assert!(pm.is_writable("p"));
+        pm.set_attrs("p", PropertyAttributes::ENUMERABLE);
+        assert!(!pm.is_writable("p"));
+        assert!(pm.is_enumerable("p"));
+        assert!(!pm.is_configurable("p"));
+    }
+
+    #[test]
+    fn test_get_with_attrs() {
+        let mut pm = PropertyMap::new();
+        pm.insert_with_attrs(
+            "x".to_string(),
+            JsValue::Smi(5),
+            PropertyAttributes::WRITABLE | PropertyAttributes::ENUMERABLE,
+        );
+        let (val, attrs) = pm.get_with_attrs("x").unwrap();
+        assert_eq!(val, &JsValue::Smi(5));
+        assert!(attrs.contains(PropertyAttributes::WRITABLE));
+        assert!(attrs.contains(PropertyAttributes::ENUMERABLE));
+        assert!(!attrs.contains(PropertyAttributes::CONFIGURABLE));
+    }
+
+    #[test]
+    fn test_iter_with_attrs() {
+        let mut pm = PropertyMap::new();
+        pm.insert_with_attrs(
+            "a".to_string(),
+            JsValue::Smi(1),
+            PropertyAttributes::WRITABLE,
+        );
+        let entries: Vec<_> = pm.iter_with_attrs().collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, "a");
+        assert_eq!(entries[0].1, &JsValue::Smi(1));
+        assert_eq!(entries[0].2, PropertyAttributes::WRITABLE);
+    }
+
+    #[test]
+    fn test_missing_key_attr_queries() {
+        let pm = PropertyMap::new();
+        assert!(!pm.is_writable("nope"));
+        assert!(!pm.is_enumerable("nope"));
+        assert!(!pm.is_configurable("nope"));
+        assert!(pm.attrs("nope").is_none());
+    }
+
+    #[test]
+    fn test_with_capacity() {
+        let pm = PropertyMap::with_capacity(16);
+        assert!(pm.is_empty());
+    }
+}

--- a/crates/stator_core/src/objects/value.rs
+++ b/crates/stator_core/src/objects/value.rs
@@ -28,7 +28,6 @@
 //!   `Vec<JsValue>` and is surfaced as [`JsValue::Iterator`].
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::builtins::error::JsError;
@@ -37,6 +36,7 @@ use crate::bytecode::bytecode_array::BytecodeArray;
 use crate::error::{StatorError, StatorResult};
 use crate::gc::trace::{Trace, Tracer};
 use crate::objects::heap_object::HeapObject;
+use crate::objects::property_map::PropertyMap;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Generator support types
@@ -268,10 +268,10 @@ pub enum JsValue {
     NativeFunction(NativeFn),
     /// A lightweight property map representing a plain JavaScript object.
     ///
-    /// Provides named-property access without going through the GC heap.
-    /// Used to construct host objects (e.g. `console`) that carry
-    /// [`NativeFunction`][Self::NativeFunction] properties.
-    PlainObject(Rc<RefCell<HashMap<String, JsValue>>>),
+    /// Each property carries [`PropertyAttributes`] flags alongside its
+    /// value, enabling ECMAScript attribute enforcement (writable,
+    /// enumerable, configurable) at the interpreter level.
+    PlainObject(Rc<RefCell<crate::objects::property_map::PropertyMap>>),
     /// A JavaScript `Promise` object backed by the [`JsPromise`] state machine.
     ///
     /// Wraps the shared-state [`JsPromise`] handle from the promise module so
@@ -685,7 +685,7 @@ impl JsValue {
             | Self::String(_)
             | Self::Symbol(_)
             | Self::BigInt(_) => {
-                let mut map = HashMap::new();
+                let mut map = PropertyMap::new();
                 map.insert("[[PrimitiveValue]]".to_string(), self.clone());
                 Ok(JsValue::PlainObject(Rc::new(RefCell::new(map))))
             }
@@ -991,7 +991,7 @@ fn string_to_number(s: &str) -> f64 {
 /// `"toString"` in the order dictated by `hint`.  Returns the first primitive
 /// result, or falls back to `"[object Object]"`.
 fn ordinary_to_primitive_plain_object(
-    map: &Rc<RefCell<HashMap<String, JsValue>>>,
+    map: &Rc<RefCell<PropertyMap>>,
     hint: ToPrimitiveHint,
 ) -> StatorResult<JsValue> {
     let method_names: [&str; 2] = match hint {
@@ -1000,7 +1000,7 @@ fn ordinary_to_primitive_plain_object(
     };
 
     for name in &method_names {
-        let maybe_fn = map.borrow().get(*name).cloned();
+        let maybe_fn = map.borrow().get(name).cloned();
         if let Some(JsValue::NativeFunction(f)) = maybe_fn {
             let result = f(vec![])?;
             if result.is_primitive() {
@@ -1254,7 +1254,7 @@ mod tests {
         assert!(JsValue::String("".to_string()).is_primitive());
         assert!(JsValue::Symbol(0).is_primitive());
         assert!(JsValue::BigInt(0).is_primitive());
-        assert!(!JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new()))).is_primitive());
+        assert!(!JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new()))).is_primitive());
         assert!(!JsValue::Array(Rc::new(vec![])).is_primitive());
     }
 
@@ -1262,7 +1262,7 @@ mod tests {
     fn test_is_object_like() {
         assert!(!JsValue::Undefined.is_object_like());
         assert!(!JsValue::Smi(42).is_object_like());
-        assert!(JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new()))).is_object_like());
+        assert!(JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new()))).is_object_like());
         assert!(JsValue::Array(Rc::new(vec![])).is_object_like());
     }
 
@@ -1349,14 +1349,14 @@ mod tests {
 
     #[test]
     fn test_to_primitive_plain_object_default() {
-        let obj = JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
+        let obj = JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new())));
         let prim = obj.to_primitive(ToPrimitiveHint::Default).unwrap();
         assert_eq!(prim, JsValue::String("[object Object]".to_string()));
     }
 
     #[test]
     fn test_to_primitive_plain_object_with_valueof() {
-        let mut map = HashMap::new();
+        let mut map = PropertyMap::new();
         let f: NativeFn = Rc::new(|_| Ok(JsValue::Smi(42)));
         map.insert("valueOf".to_string(), JsValue::NativeFunction(f));
         let obj = JsValue::PlainObject(Rc::new(RefCell::new(map)));
@@ -1367,7 +1367,7 @@ mod tests {
 
     #[test]
     fn test_to_primitive_plain_object_with_tostring() {
-        let mut map = HashMap::new();
+        let mut map = PropertyMap::new();
         let f: NativeFn = Rc::new(|_| Ok(JsValue::String("custom".to_string())));
         map.insert("toString".to_string(), JsValue::NativeFunction(f));
         let obj = JsValue::PlainObject(Rc::new(RefCell::new(map)));
@@ -1515,7 +1515,7 @@ mod tests {
 
     #[test]
     fn test_to_number_plain_object_is_nan() {
-        let obj = JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
+        let obj = JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new())));
         let n = obj.to_number().unwrap();
         assert!(n.is_nan());
     }
@@ -1625,7 +1625,7 @@ mod tests {
 
     #[test]
     fn test_to_js_string_plain_object() {
-        let obj = JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
+        let obj = JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new())));
         assert_eq!(obj.to_js_string().unwrap(), "[object Object]");
     }
 
@@ -1773,7 +1773,7 @@ mod tests {
 
     #[test]
     fn test_to_object_object_passthrough() {
-        let obj = JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new())));
+        let obj = JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new())));
         let result = obj.to_object().unwrap();
         assert!(result.is_object_like());
     }

--- a/crates/stator_core/src/snapshot/mod.rs
+++ b/crates/stator_core/src/snapshot/mod.rs
@@ -116,6 +116,7 @@ use crate::bytecode::bytecode_array::{
 };
 use crate::bytecode::feedback::{FeedbackMetadata, FeedbackSlotKind};
 use crate::error::{StatorError, StatorResult};
+use crate::objects::property_map::PropertyMap;
 use crate::objects::value::JsValue;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -817,7 +818,7 @@ fn read_defined_ref(
     match inner_tag {
         TAG_PLAIN_OBJECT => {
             let count = read_u32(bytes, cursor)? as usize;
-            let map = Rc::new(RefCell::new(HashMap::with_capacity(count)));
+            let map = Rc::new(RefCell::new(PropertyMap::with_capacity(count)));
             let value = JsValue::PlainObject(Rc::clone(&map));
             // Register before reading entries to allow circular references.
             ctx.register(ref_id, value.clone());
@@ -906,7 +907,7 @@ fn read_jsvalue_by_tag(
         }
         TAG_PLAIN_OBJECT => {
             let count = read_u32(bytes, cursor)? as usize;
-            let mut map = HashMap::with_capacity(count);
+            let mut map = PropertyMap::with_capacity(count);
             for _ in 0..count {
                 let k = read_str32(bytes, cursor)?;
                 let v = read_jsvalue(bytes, cursor, ctx)?;
@@ -1269,7 +1270,7 @@ mod tests {
 
     #[test]
     fn test_round_trip_plain_object() {
-        let mut map = HashMap::new();
+        let mut map = PropertyMap::new();
         map.insert("x".to_string(), JsValue::Smi(10));
         map.insert("y".to_string(), JsValue::Boolean(true));
         let mut g = HashMap::new();
@@ -1582,10 +1583,9 @@ mod tests {
 
     #[test]
     fn test_round_trip_shared_plain_object() {
-        let shared = Rc::new(RefCell::new(HashMap::from([(
-            "x".to_string(),
-            JsValue::Smi(1),
-        )])));
+        let mut shared_map = PropertyMap::new();
+        shared_map.insert("x".to_string(), JsValue::Smi(1));
+        let shared = Rc::new(RefCell::new(shared_map));
         let mut g = HashMap::new();
         g.insert("a".to_string(), JsValue::PlainObject(Rc::clone(&shared)));
         g.insert("b".to_string(), JsValue::PlainObject(Rc::clone(&shared)));
@@ -1604,7 +1604,7 @@ mod tests {
 
     #[test]
     fn test_round_trip_circular_plain_object() {
-        let obj = Rc::new(RefCell::new(HashMap::new()));
+        let obj = Rc::new(RefCell::new(PropertyMap::new()));
         obj.borrow_mut()
             .insert("self".to_string(), JsValue::PlainObject(Rc::clone(&obj)));
         obj.borrow_mut().insert("val".to_string(), JsValue::Smi(42));
@@ -1677,11 +1677,10 @@ mod tests {
     #[test]
     fn test_round_trip_prototype_chain() {
         // Simulate a prototype chain: child.__proto__ = parent
-        let parent = Rc::new(RefCell::new(HashMap::from([(
-            "greet".to_string(),
-            JsValue::String("hello".to_string()),
-        )])));
-        let mut child_map = HashMap::new();
+        let mut parent_map = PropertyMap::new();
+        parent_map.insert("greet".to_string(), JsValue::String("hello".to_string()));
+        let parent = Rc::new(RefCell::new(parent_map));
+        let mut child_map = PropertyMap::new();
         child_map.insert("x".to_string(), JsValue::Smi(10));
         child_map.insert(
             "__proto__".to_string(),
@@ -1690,7 +1689,7 @@ mod tests {
         let child = Rc::new(RefCell::new(child_map));
 
         // A second child shares the same parent prototype.
-        let mut child2_map = HashMap::new();
+        let mut child2_map = PropertyMap::new();
         child2_map.insert("y".to_string(), JsValue::Smi(20));
         child2_map.insert(
             "__proto__".to_string(),

--- a/crates/stator_ffi/src/lib.rs
+++ b/crates/stator_ffi/src/lib.rs
@@ -25,6 +25,7 @@ use stator_core::dom::{
 use stator_core::gc::heap::Heap;
 use stator_core::interpreter::{Interpreter, InterpreterFrame};
 use stator_core::objects::js_object::JsObject;
+use stator_core::objects::property_map::PropertyMap;
 use stator_core::objects::value::{JsValue, NativeFn};
 use stator_core::parser;
 use stator_core::wasm::{WasmEngine, WasmInstance, WasmModule};
@@ -2397,7 +2398,7 @@ pub unsafe extern "C" fn stator_register_native_function(
         // Insert the parent object if it doesn't exist yet.
         let obj = env
             .entry(obj_name.to_owned())
-            .or_insert_with(|| JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new()))))
+            .or_insert_with(|| JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new()))))
             .clone();
         drop(env); // release borrow before we potentially re-borrow
 
@@ -2704,7 +2705,7 @@ pub unsafe extern "C" fn stator_context_global_set(
         let mut env = globals.borrow_mut();
         let obj = env
             .entry(obj_name.to_owned())
-            .or_insert_with(|| JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new()))))
+            .or_insert_with(|| JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new()))))
             .clone();
         drop(env);
 
@@ -2847,7 +2848,7 @@ fn stator_value_inner_to_jsvalue(inner: &StatorValueInner) -> JsValue {
         | StatorValueInner::RegExp
         | StatorValueInner::Promise
         | StatorValueInner::Map
-        | StatorValueInner::Set => JsValue::PlainObject(Rc::new(RefCell::new(HashMap::new()))),
+        | StatorValueInner::Set => JsValue::PlainObject(Rc::new(RefCell::new(PropertyMap::new()))),
         StatorValueInner::Function => {
             // Return a no-op native function to preserve the callable nature.
             JsValue::NativeFunction(Rc::new(|_| Ok(JsValue::Undefined)))

--- a/crates/stator_test262/src/main.rs
+++ b/crates/stator_test262/src/main.rs
@@ -28,6 +28,7 @@ use stator_core::builtins::install_globals::install_globals;
 use stator_core::bytecode::bytecode_generator::BytecodeGenerator;
 use stator_core::error::StatorError;
 use stator_core::interpreter::{Interpreter, InterpreterFrame};
+use stator_core::objects::property_map::PropertyMap;
 use stator_core::objects::value::JsValue;
 use stator_core::parser;
 
@@ -333,7 +334,7 @@ fn make_test_globals() -> HashMap<String, JsValue> {
     );
 
     // Minimal $262 host-defined object.
-    let obj_262: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let obj_262: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
     obj_262.borrow_mut().insert(
         "gc".to_string(),
         JsValue::NativeFunction(Rc::new(|_| Ok(JsValue::Undefined))),
@@ -345,7 +346,7 @@ fn make_test_globals() -> HashMap<String, JsValue> {
     map.insert("$262".to_string(), JsValue::PlainObject(obj_262));
 
     // ── Native Test262Error constructor ──────────────────────────────────
-    let t262_proto: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let t262_proto: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
     t262_proto.borrow_mut().insert(
         "toString".to_string(),
         JsValue::NativeFunction(Rc::new(|_args| {
@@ -354,7 +355,7 @@ fn make_test_globals() -> HashMap<String, JsValue> {
     );
     let t262_proto_val = JsValue::PlainObject(t262_proto.clone());
 
-    let t262_ctor: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let t262_ctor: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
     let proto_for_ctor = t262_proto_val.clone();
     t262_ctor.borrow_mut().insert(
         "__call__".to_string(),
@@ -363,7 +364,7 @@ fn make_test_globals() -> HashMap<String, JsValue> {
                 .first()
                 .cloned()
                 .unwrap_or(JsValue::String(String::new()));
-            let obj: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+            let obj: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
             obj.borrow_mut().insert("message".to_string(), msg);
             obj.borrow_mut()
                 .insert("__proto__".to_string(), proto_for_ctor.clone());
@@ -396,7 +397,7 @@ fn make_test_globals() -> HashMap<String, JsValue> {
     );
 
     // ── Native assert harness ────────────────────────────────────────────
-    let assert_obj: Rc<RefCell<HashMap<String, JsValue>>> = Rc::new(RefCell::new(HashMap::new()));
+    let assert_obj: Rc<RefCell<PropertyMap>> = Rc::new(RefCell::new(PropertyMap::new()));
 
     // assert(mustBeTrue, message) — base callable.
     assert_obj.borrow_mut().insert(


### PR DESCRIPTION
Implements property descriptor enforcement for Test262 compliance.

## Changes

- **New PropertyMap type** (crates/stator_core/src/objects/property_map.rs): A HashMap-like store that pairs each value with PropertyAttributes flags (writable, enumerable, configurable). Replaces the bare HashMap<String, JsValue> inside JsValue::PlainObject.

- **Non-writable enforcement**: StaNamedProperty and keyed_store in the interpreter now silently skip writes to non-writable properties (sloppy mode behavior per §10.1.9).

- **Non-configurable enforcement**: DeletePropertySloppy returns alse for non-configurable properties; DeletePropertyStrict throws TypeError (per §10.1.10).

- **Non-enumerable enforcement**: ForInEnumerate now only yields enumerable keys (per §14.7.5.9).

- **PlainObject migration**: All 18 files updated from HashMap<String, JsValue> to PropertyMap. Existing JsObject-level enforcement (Object.freeze/seal/defineProperty, etc.) is unchanged.

All 3302 tests pass (2 pre-existing turbofan failures remain).