### PR TITLE
feat: strict mode enforcement for Test262 compliance (closes #383)

### DIFF
--- a/crates/stator_core/src/builtins/install_globals.rs
+++ b/crates/stator_core/src/builtins/install_globals.rs
@@ -5694,7 +5694,7 @@ fn require_object_arg(args: &[JsValue], idx: usize, name: &str) -> StatorResult<
 
 /// Build the `ArrayBuffer` constructor object.
 fn make_arraybuffer() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // ArrayBuffer(byteLength)
     props.insert(
@@ -5723,7 +5723,7 @@ fn make_arraybuffer() -> JsValue {
 
 /// Build the `DataView` constructor object.
 fn make_dataview() -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     props.insert(
         "__call__".into(),
@@ -5921,7 +5921,7 @@ fn num_value<T: Into<f64>>(v: T) -> JsValue {
 
 /// Build a typed-array constructor for the given `TypedArrayKind`.
 fn make_typed_array_constructor(kind: TypedArrayKind) -> JsValue {
-    let mut props: HashMap<String, JsValue> = HashMap::new();
+    let mut props = PropertyMap::new();
 
     // BYTES_PER_ELEMENT
     props.insert(
@@ -6001,7 +6001,7 @@ fn make_typed_array_instance(
 ) -> JsValue {
     let _ = kind;
     let typed_array_val = JsValue::TypedArray(Rc::clone(&inner));
-    let mut obj: HashMap<String, JsValue> = HashMap::new();
+    let mut obj = PropertyMap::new();
 
     // BYTES_PER_ELEMENT
     {

--- a/crates/stator_core/src/bytecode/bytecode_array.rs
+++ b/crates/stator_core/src/bytecode/bytecode_array.rs
@@ -237,6 +237,8 @@ pub struct BytecodeArray {
     is_async: bool,
     /// `true` if this bytecode belongs to an ES module (as opposed to a script).
     is_module: bool,
+    /// `true` if this bytecode was compiled in strict mode (`"use strict"`).
+    is_strict: bool,
     // ─── Tiering state (shared across clones via Rc / Arc) ───────────────────
     /// Number of times this function has been invoked.
     ///
@@ -288,6 +290,7 @@ impl PartialEq for BytecodeArray {
             && self.is_generator == other.is_generator
             && self.is_async == other.is_async
             && self.is_module == other.is_module
+            && self.is_strict == other.is_strict
     }
 }
 
@@ -325,6 +328,7 @@ impl BytecodeArray {
             is_generator: false,
             is_async: false,
             is_module: false,
+            is_strict: false,
             invocation_count: Rc::new(Cell::new(0)),
             jit_code: Rc::new(RefCell::new(None)),
             maglev_jit_code: Arc::new(Mutex::new(None)),
@@ -378,6 +382,17 @@ impl BytecodeArray {
     /// Returns `true` if this bytecode belongs to an ES module.
     pub fn is_module(&self) -> bool {
         self.is_module
+    }
+
+    /// Mark this [`BytecodeArray`] as compiled in strict mode.
+    pub fn with_strict_flag(mut self, flag: bool) -> Self {
+        self.is_strict = flag;
+        self
+    }
+
+    /// Returns `true` if this bytecode was compiled in strict mode.
+    pub fn is_strict(&self) -> bool {
+        self.is_strict
     }
 
     /// The raw encoded bytecode bytes.

--- a/crates/stator_core/src/bytecode/bytecode_generator.rs
+++ b/crates/stator_core/src/bytecode/bytecode_generator.rs
@@ -225,6 +225,8 @@ struct FunctionCompiler {
     /// [`compile_method_call`] to emit [`Opcode::TailCall`] instead of a
     /// regular call.
     in_tail_position: bool,
+    /// `true` when compiling in strict mode.
+    is_strict: bool,
 }
 
 impl FunctionCompiler {
@@ -259,6 +261,7 @@ impl FunctionCompiler {
             module_variables: HashMap::new(),
             next_module_cell: 0,
             in_tail_position: false,
+            is_strict: false,
         };
         // Register simple ident params in the scope immediately; complex
         // patterns are handled by `emit_param_prologue`.
@@ -769,8 +772,13 @@ impl FunctionCompiler {
     /// resulting [`BytecodeArray`] to the constant pool, emit `CreateClosure`,
     /// and bind the name to the resulting register.
     fn compile_fn_decl(&mut self, decl: &FnDecl) -> StatorResult<()> {
-        let func_array =
-            compile_function(&decl.params, &decl.body, decl.is_generator, decl.is_async)?;
+        let func_array = compile_function(
+            &decl.params,
+            &decl.body,
+            decl.is_generator,
+            decl.is_async,
+            decl.is_strict,
+        )?;
         let pool_idx = self.add_constant_raw(ConstantPoolEntry::Function(Box::new(func_array)));
         // Emit CreateClosure: [func_idx, slot, flags]
         let slot = self.alloc_slot(FeedbackSlotKind::CreateClosure);
@@ -856,13 +864,19 @@ impl FunctionCompiler {
             _ => None,
         });
         let ctor_array = if let Some(ctor) = ctor_method {
-            compile_function(&ctor.value.params, &ctor.value.body, false, false)?
+            compile_function(
+                &ctor.value.params,
+                &ctor.value.body,
+                false,
+                false,
+                self.is_strict,
+            )?
         } else {
             let empty_body = BlockStmt {
                 loc: body.loc,
                 body: vec![],
             };
-            compile_function(&[], &empty_body, false, false)?
+            compile_function(&[], &empty_body, false, false, self.is_strict)?
         };
         let ctor_idx = self.add_constant_raw(ConstantPoolEntry::Function(Box::new(ctor_array)));
         let slot = self.alloc_slot(FeedbackSlotKind::CreateClosure);
@@ -1212,6 +1226,7 @@ impl FunctionCompiler {
             module_variables: HashMap::new(),
             next_module_cell: 0,
             in_tail_position: false,
+            is_strict: false,
         };
 
         let this_reg = Register::parameter(0);
@@ -1985,7 +2000,7 @@ impl FunctionCompiler {
                 self.emit(Instruction::new_unchecked(Opcode::BitwiseNot, vec![slot]));
             }
             UnaryOp::Delete => {
-                // Simplified: compile argument, emit sloppy-mode delete.
+                // Emit strict or sloppy delete depending on compilation mode.
                 match u.argument.as_ref() {
                     Expr::Member(m) => {
                         self.compile_expr(&m.object)?;
@@ -2008,16 +2023,29 @@ impl FunctionCompiler {
                                 ));
                             }
                         }
+                        let delete_op = if self.is_strict {
+                            Opcode::DeletePropertyStrict
+                        } else {
+                            Opcode::DeletePropertySloppy
+                        };
                         self.emit(Instruction::new_unchecked(
-                            Opcode::DeletePropertySloppy,
+                            delete_op,
                             vec![to_reg_op(obj_reg)],
                         ));
                         self.allocator
                             .release_temporary(obj_reg)
                             .map_err(|e| StatorError::Internal(e.to_string()))?;
                     }
+                    Expr::Ident(_) if self.is_strict => {
+                        // In strict mode, `delete x` on an unqualified
+                        // identifier is a SyntaxError.
+                        return Err(StatorError::SyntaxError(
+                            "delete of an unqualified identifier is not allowed in strict mode"
+                                .into(),
+                        ));
+                    }
                     _ => {
-                        // delete on non-member always returns true.
+                        // delete on non-member always returns true in sloppy mode.
                         self.emit(Instruction::new_unchecked(Opcode::LdaTrue, vec![]));
                     }
                 }
@@ -2800,7 +2828,8 @@ impl FunctionCompiler {
 
     /// Compile a function expression.
     fn compile_fn_expr(&mut self, f: &FnExpr) -> StatorResult<()> {
-        let func_array = compile_function(&f.params, &f.body, f.is_generator, f.is_async)?;
+        let func_array =
+            compile_function(&f.params, &f.body, f.is_generator, f.is_async, f.is_strict)?;
         let pool_idx = self.add_constant_raw(ConstantPoolEntry::Function(Box::new(func_array)));
         let slot = self.alloc_slot(FeedbackSlotKind::CreateClosure);
         self.emit(Instruction::new_unchecked(
@@ -2828,7 +2857,7 @@ impl FunctionCompiler {
                 }
             }
         };
-        let func_array = compile_function(&a.params, &body_block, false, a.is_async)?;
+        let func_array = compile_function(&a.params, &body_block, false, a.is_async, a.is_strict)?;
         let pool_idx = self.add_constant_raw(ConstantPoolEntry::Function(Box::new(func_array)));
         let slot = self.alloc_slot(FeedbackSlotKind::CreateClosure);
         self.emit(Instruction::new_unchecked(
@@ -4093,7 +4122,8 @@ impl FunctionCompiler {
         Ok(ba
             .with_generator_flag(self.is_generator)
             .with_async_flag(self.is_async)
-            .with_module_flag(self.is_module))
+            .with_module_flag(self.is_module)
+            .with_strict_flag(self.is_strict))
     }
 }
 
@@ -4167,10 +4197,12 @@ fn compile_function(
     body: &BlockStmt,
     is_generator: bool,
     is_async: bool,
+    is_strict: bool,
 ) -> StatorResult<BytecodeArray> {
     let mut compiler = FunctionCompiler::new(params)?;
     compiler.is_generator = is_generator;
     compiler.is_async = is_async;
+    compiler.is_strict = is_strict;
 
     // Generator / async / async-generator prologue: jump to the saved resume
     // point on re-entry.  Async functions are desugared to generators internally,
@@ -4220,6 +4252,7 @@ fn compile_function(
 ///     loc,
 ///     source_type: SourceType::Script,
 ///     body: vec![],
+///     is_strict: false,
 /// };
 /// let array = BytecodeGenerator::compile_program(&program)
 ///     .expect("compilation should succeed");
@@ -4237,6 +4270,8 @@ impl BytecodeGenerator {
         compiler.is_program = true;
         let is_module = program.source_type == SourceType::Module;
         compiler.is_module = is_module;
+        // Modules are always strict; scripts inherit the AST flag.
+        compiler.is_strict = program.is_strict || is_module;
 
         // Hoist function declarations to the top.
         for item in &program.body {
@@ -4271,6 +4306,7 @@ impl BytecodeGenerator {
         let mut compiler = FunctionCompiler::new(&[])?;
         compiler.is_program = true;
         compiler.is_eval_scope = true;
+        compiler.is_strict = program.is_strict;
 
         for item in &program.body {
             if let ProgramItem::Stmt(Stmt::FnDecl(decl)) = item {
@@ -4382,6 +4418,7 @@ mod tests {
             loc: span(),
             source_type: SourceType::Script,
             body: stmts.into_iter().map(ProgramItem::Stmt).collect(),
+            is_strict: false,
         }
     }
 
@@ -4745,6 +4782,7 @@ mod tests {
                 },
             ],
             body,
+            is_strict: false,
         }))]);
         let arr = BytecodeGenerator::compile_program(&prog).unwrap();
         let instrs = arr.instructions().unwrap();
@@ -4783,6 +4821,7 @@ mod tests {
                 },
             ],
             &body,
+            false,
             false,
             false,
         )
@@ -5111,6 +5150,7 @@ mod tests {
                 },
             ],
             body,
+            is_strict: false,
         }))]);
         let kinds = slot_kinds_for(&prog);
         assert!(
@@ -5364,6 +5404,7 @@ mod tests {
             body: BlockStmt { loc: span(), body },
             is_generator: true,
             is_async: false,
+            is_strict: false,
         }
     }
 
@@ -5605,6 +5646,7 @@ mod tests {
             },
             is_generator: true,
             is_async: false,
+            is_strict: false,
         };
         let prog = make_program(vec![Stmt::FnDecl(Box::new(decl))]);
         // Must compile without error.
@@ -5813,6 +5855,7 @@ mod tests {
                 loc: span(),
                 body: vec![],
             },
+            is_strict: false,
         }
     }
 
@@ -5968,6 +6011,7 @@ mod tests {
             body: BlockStmt { loc: span(), body },
             is_generator: true,
             is_async: true,
+            is_strict: false,
         }
     }
 
@@ -6062,6 +6106,7 @@ mod tests {
             },
             is_generator: true,
             is_async: true,
+            is_strict: false,
         }));
         let prog = make_program(vec![var_decl_stmt(VarKind::Var, "f", Some(fn_expr))]);
         let arr = BytecodeGenerator::compile_program(&prog).unwrap();
@@ -6418,6 +6463,7 @@ mod tests {
             },
             is_generator: false,
             is_async: true,
+            is_strict: false,
         };
         let prog = make_program(vec![Stmt::FnDecl(Box::new(decl))]);
         let arr = BytecodeGenerator::compile_program(&prog).unwrap();
@@ -6457,6 +6503,7 @@ mod tests {
             },
             is_generator: false,
             is_async: true,
+            is_strict: false,
         }));
         let prog = make_program(vec![var_decl_stmt(VarKind::Var, "f", Some(fn_expr))]);
         let arr = BytecodeGenerator::compile_program(&prog).unwrap();
@@ -6481,6 +6528,7 @@ mod tests {
                 body: vec![await_stmt(num_expr(1.0))],
             }),
             is_async: true,
+            is_strict: false,
         }));
         let prog = make_program(vec![var_decl_stmt(VarKind::Var, "f", Some(arrow))]);
         let arr = BytecodeGenerator::compile_program(&prog).unwrap();
@@ -6636,6 +6684,7 @@ mod tests {
             &body,
             false,
             false,
+            false,
         )
         .unwrap();
         let instrs = inner.instructions().unwrap();
@@ -6676,6 +6725,7 @@ mod tests {
             &body,
             false,
             false,
+            false,
         )
         .unwrap();
         let instrs = inner.instructions().unwrap();
@@ -6706,6 +6756,7 @@ mod tests {
                 default: None,
             }],
             &body,
+            false,
             false,
             false,
         )
@@ -6749,6 +6800,7 @@ mod tests {
             &body,
             false,
             false,
+            false,
         )
         .unwrap();
         let instrs = inner.instructions().unwrap();
@@ -6784,6 +6836,7 @@ mod tests {
                 },
             ],
             &body,
+            false,
             false,
             false,
         )
@@ -6829,6 +6882,7 @@ mod tests {
             &body,
             false,
             false,
+            false,
         )
         .unwrap();
         let instrs = inner.instructions().unwrap();
@@ -6857,6 +6911,7 @@ mod tests {
                 default: None,
             }],
             &body,
+            false,
             false,
             false,
         )
@@ -6900,6 +6955,7 @@ mod tests {
             loc: span(),
             source_type: SourceType::Module,
             body: items,
+            is_strict: true,
         }
     }
 
@@ -7156,6 +7212,7 @@ mod tests {
                 source: string_lit("./mod.js"),
                 attributes: vec![],
             }))],
+            is_strict: false,
         };
         let result = BytecodeGenerator::compile_program(&prog);
         assert!(result.is_err(), "module decl in script should error");

--- a/crates/stator_core/src/interpreter/mod.rs
+++ b/crates/stator_core/src/interpreter/mod.rs
@@ -2706,6 +2706,7 @@ mod tests {
             loc: span(),
             source_type: SourceType::Script,
             body: stmts.into_iter().map(ProgramItem::Stmt).collect(),
+            is_strict: false,
         };
         let ba = BytecodeGenerator::compile_program(&program)?;
         let mut frame = InterpreterFrame::new(ba, vec![]);
@@ -3080,6 +3081,7 @@ mod tests {
                     ident_expr("b"),
                 )))],
             },
+            is_strict: false,
         }));
 
         // return add(3, 4);
@@ -3113,6 +3115,7 @@ mod tests {
                 loc: span(),
                 body: vec![return_stmt(Some(num_expr(42.0)))],
             },
+            is_strict: false,
         }));
 
         let call_stmt = return_stmt(Some(Expr::Call(Box::new(CallExpr {
@@ -3156,6 +3159,7 @@ mod tests {
                     num_expr(2.0),
                 )))],
             },
+            is_strict: false,
         }));
 
         let call_stmt = return_stmt(Some(Expr::Call(Box::new(CallExpr {
@@ -3203,6 +3207,7 @@ mod tests {
                     num_expr(1.0),
                 )))],
             },
+            is_strict: false,
         }));
 
         let new_stmt = return_stmt(Some(Expr::New(Box::new(NewExpr {

--- a/crates/stator_core/src/parser/ast.rs
+++ b/crates/stator_core/src/parser/ast.rs
@@ -46,6 +46,8 @@ pub struct Program {
     pub source_type: SourceType,
     /// Top-level statements and module declarations.
     pub body: Vec<ProgramItem>,
+    /// `true` when the source begins with a `"use strict"` directive prologue.
+    pub is_strict: bool,
 }
 
 /// A top-level item inside a [`Program`].
@@ -459,6 +461,9 @@ pub struct FnDecl {
     pub params: Vec<Param>,
     /// Function body.
     pub body: BlockStmt,
+    /// `true` when the function body has a `"use strict"` directive prologue
+    /// or inherits strict mode from an enclosing strict context.
+    pub is_strict: bool,
 }
 
 /// `function [id] (params) { body }` used as an expression.
@@ -476,6 +481,9 @@ pub struct FnExpr {
     pub params: Vec<Param>,
     /// Function body.
     pub body: BlockStmt,
+    /// `true` when the function body has a `"use strict"` directive prologue
+    /// or inherits strict mode from an enclosing strict context.
+    pub is_strict: bool,
 }
 
 /// `[async] (params) => body`
@@ -489,6 +497,8 @@ pub struct ArrowExpr {
     pub params: Vec<Param>,
     /// Either a block body `{ … }` or a concise expression body.
     pub body: ArrowBody,
+    /// `true` when the arrow inherits strict mode from an enclosing context.
+    pub is_strict: bool,
 }
 
 /// The body of an arrow function.
@@ -1545,6 +1555,7 @@ mod tests {
             loc: dummy_loc(),
             source_type: SourceType::Script,
             body: vec![],
+            is_strict: false,
         };
         assert!(prog.body.is_empty());
         assert_eq!(prog.source_type, SourceType::Script);
@@ -1557,6 +1568,7 @@ mod tests {
             loc: dummy_loc(),
             source_type: SourceType::Module,
             body: vec![ProgramItem::Stmt(stmt)],
+            is_strict: true,
         };
         assert_eq!(prog.body.len(), 1);
     }
@@ -1594,6 +1606,7 @@ mod tests {
                 is_generator: false,
                 params: vec![],
                 body: BlockStmt { loc, body: vec![] },
+                is_strict: false,
             })),
             Stmt::ClassDecl(Box::new(ClassDecl {
                 loc,
@@ -1769,12 +1782,14 @@ mod tests {
                 is_generator: false,
                 params: vec![],
                 body: BlockStmt { loc, body: vec![] },
+                is_strict: false,
             })),
             Expr::Arrow(Box::new(ArrowExpr {
                 loc,
                 is_async: false,
                 params: vec![],
                 body: ArrowBody::Expr(null()),
+                is_strict: false,
             })),
             Expr::Class(Box::new(ClassExpr {
                 loc,

--- a/crates/stator_core/src/parser/recursive_descent.rs
+++ b/crates/stator_core/src/parser/recursive_descent.rs
@@ -74,6 +74,10 @@ pub struct Parser<'src> {
     /// and decremented when leaving.  Used to validate that `#private`
     /// identifiers only appear inside a class.
     class_depth: usize,
+    /// `true` when the parser is inside a strict-mode context (either the
+    /// top-level program had a `"use strict"` directive or we are inside a
+    /// function whose body contains one).
+    strict_mode: bool,
 }
 
 impl<'src> Parser<'src> {
@@ -89,6 +93,7 @@ impl<'src> Parser<'src> {
             no_in: false,
             depth: 0,
             class_depth: 0,
+            strict_mode: false,
         })
     }
 
@@ -198,6 +203,25 @@ impl<'src> Parser<'src> {
         Ok(())
     }
 
+    /// Check whether the current token is a `"use strict"` directive string.
+    fn is_use_strict_directive(&self) -> bool {
+        if self.current.kind != TokenKind::StringLiteral {
+            return false;
+        }
+        matches!(
+            &self.current.value,
+            TokenValue::Str(s) if s == "\"use strict\"" || s == "'use strict'"
+        )
+    }
+
+    /// Detect a `"use strict"` directive prologue at the start of a body.
+    /// Returns `true` if a directive was found.  Does **not** consume any
+    /// tokens — the directive is still parsed as a normal expression
+    /// statement later.
+    fn check_directive_prologue(&self) -> bool {
+        self.is_use_strict_directive()
+    }
+
     // ── Top-level ────────────────────────────────────────────────────────────
 
     /// Parse a complete source file as a [`Program`].
@@ -210,6 +234,12 @@ impl<'src> Parser<'src> {
         let start = self.current_span();
         let mut body = Vec::new();
         let mut is_module = false;
+
+        // Detect "use strict" directive prologue.
+        let is_strict = self.check_directive_prologue();
+        if is_strict {
+            self.strict_mode = true;
+        }
 
         while self.peek_kind() != TokenKind::Eof {
             match self.peek_kind() {
@@ -245,6 +275,8 @@ impl<'src> Parser<'src> {
         }
 
         let end = self.current_span();
+        // Modules are always strict.
+        let is_strict = is_strict || is_module;
         Ok(Program {
             loc: Self::merge_spans(start, end),
             source_type: if is_module {
@@ -253,6 +285,7 @@ impl<'src> Parser<'src> {
                 SourceType::Script
             },
             body,
+            is_strict,
         })
     }
 
@@ -741,6 +774,9 @@ impl<'src> Parser<'src> {
 
     /// Parse a `with (expr) stmt` statement (sloppy mode only).
     fn parse_with(&mut self) -> StatorResult<Stmt> {
+        if self.strict_mode {
+            return Err(self.error("'with' statements are not allowed in strict mode"));
+        }
         let start = self.current_span();
         self.bump()?; // 'with'
         self.expect(TokenKind::LeftParen)?;
@@ -820,7 +856,12 @@ impl<'src> Parser<'src> {
         };
         self.expect(TokenKind::LeftParen)?;
         let params = self.parse_formal_params()?;
-        let body = self.parse_block()?;
+
+        // Save enclosing strict mode, then parse function body.
+        let outer_strict = self.strict_mode;
+        let (body, fn_strict) = self.parse_function_body()?;
+        self.strict_mode = outer_strict;
+
         let end = body.loc;
         Ok(Stmt::FnDecl(Box::new(FnDecl {
             loc: Self::merge_spans(fn_span, end),
@@ -829,7 +870,40 @@ impl<'src> Parser<'src> {
             is_generator,
             params,
             body,
+            is_strict: fn_strict,
         })))
+    }
+
+    /// Parse a function body block `{ … }`, detecting a `"use strict"`
+    /// directive prologue.  Returns `(block, is_strict)` where `is_strict`
+    /// is `true` when the function inherits or declares strict mode.
+    fn parse_function_body(&mut self) -> StatorResult<(BlockStmt, bool)> {
+        let start = self.current_span();
+        self.expect(TokenKind::LeftBrace)?;
+
+        // Check for "use strict" directive before parsing statements.
+        let has_directive = self.check_directive_prologue();
+        let is_strict = self.strict_mode || has_directive;
+        if has_directive {
+            self.strict_mode = true;
+        }
+
+        let mut body = Vec::new();
+        while self.peek_kind() != TokenKind::RightBrace {
+            if self.peek_kind() == TokenKind::Eof {
+                return Err(self.error("unexpected end of input inside block"));
+            }
+            body.push(self.parse_stmt()?);
+        }
+        let end = self.current_span();
+        self.bump()?; // consume '}'
+        Ok((
+            BlockStmt {
+                loc: Self::merge_spans(start, end),
+                body,
+            },
+            is_strict,
+        ))
     }
 
     // ── Class parsing ──────────────────────────────────────────────────────
@@ -1008,6 +1082,7 @@ impl<'src> Parser<'src> {
                     is_generator,
                     params,
                     body,
+                    is_strict: false,
                 };
 
                 members.push(ClassMember::Method(MethodDef {
@@ -1560,6 +1635,14 @@ impl<'src> Parser<'src> {
             TokenKind::Identifier => {
                 let tok = self.bump()?;
                 let ident = self.ident_from_token(&tok)?;
+                // In strict mode, `eval` and `arguments` cannot be used as
+                // binding identifiers.
+                if self.strict_mode && (ident.name == "eval" || ident.name == "arguments") {
+                    return Err(self.error(&format!(
+                        "'{}' cannot be used as a binding name in strict mode",
+                        ident.name
+                    )));
+                }
                 Ok(Pat::Ident(ident))
             }
             TokenKind::LeftBracket => self.parse_array_pat(),
@@ -1837,6 +1920,7 @@ impl<'src> Parser<'src> {
                                 is_async: true,
                                 params: vec![],
                                 body,
+                                is_strict: self.strict_mode,
                             })));
                         }
                         // `async()` not followed by `=>` — restore to just
@@ -1870,6 +1954,7 @@ impl<'src> Parser<'src> {
                             is_async: true,
                             params,
                             body,
+                            is_strict: self.strict_mode,
                         })));
                     }
                     // Not `async x =>` — restore to just after `async`.
@@ -1932,6 +2017,7 @@ impl<'src> Parser<'src> {
                         is_async: false,
                         params: vec![],
                         body,
+                        is_strict: self.strict_mode,
                     })));
                 }
                 // `()` not followed by `=>` — restore and let normal
@@ -1975,6 +2061,7 @@ impl<'src> Parser<'src> {
                     is_async: true,
                     params,
                     body,
+                    is_strict: self.strict_mode,
                 })));
             }
 
@@ -1986,6 +2073,7 @@ impl<'src> Parser<'src> {
                 is_async: false,
                 params,
                 body,
+                is_strict: self.strict_mode,
             })));
         }
 
@@ -2739,6 +2827,7 @@ impl<'src> Parser<'src> {
                                 is_generator: false,
                                 params,
                                 body,
+                                is_strict: false,
                             };
                             match accessor_kind {
                                 MethodKind::Get => PropValue::Get(fn_expr),
@@ -2763,6 +2852,7 @@ impl<'src> Parser<'src> {
                                 is_generator: is_generator_method,
                                 params,
                                 body,
+                                is_strict: false,
                             })
                         } else if self.eat(TokenKind::Colon)? {
                             PropValue::Value(Box::new(self.parse_assignment_expr()?))
@@ -3059,7 +3149,11 @@ impl<'src> Parser<'src> {
         };
         self.expect(TokenKind::LeftParen)?;
         let params = self.parse_formal_params()?;
-        let body = self.parse_block()?;
+
+        let outer_strict = self.strict_mode;
+        let (body, fn_strict) = self.parse_function_body()?;
+        self.strict_mode = outer_strict;
+
         let end = body.loc;
         Ok(Expr::Fn(Box::new(crate::parser::ast::FnExpr {
             loc: Self::merge_spans(fn_span, end),
@@ -3068,6 +3162,7 @@ impl<'src> Parser<'src> {
             is_generator,
             params,
             body,
+            is_strict: fn_strict,
         })))
     }
 
@@ -6662,5 +6757,65 @@ mod tests {
             ProgramItem::ModuleDecl(ModuleDecl::Import(_))
         ));
         assert_eq!(prog.source_type, SourceType::Module);
+    }
+
+    // ── Strict mode tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_use_strict_directive_sets_flag() {
+        let prog = parse("\"use strict\"; var x = 1;").unwrap();
+        assert!(prog.is_strict);
+    }
+
+    #[test]
+    fn test_no_use_strict_directive_is_sloppy() {
+        let prog = parse("var x = 1;").unwrap();
+        assert!(!prog.is_strict);
+    }
+
+    #[test]
+    fn test_module_is_always_strict() {
+        let prog = parse("import x from 'y';").unwrap();
+        assert!(prog.is_strict);
+    }
+
+    #[test]
+    fn test_strict_mode_function() {
+        let prog = parse("function f() { \"use strict\"; return 1; }").unwrap();
+        if let ProgramItem::Stmt(Stmt::FnDecl(decl)) = &prog.body[0] {
+            assert!(decl.is_strict);
+        } else {
+            panic!("expected FnDecl");
+        }
+    }
+
+    #[test]
+    fn test_strict_mode_with_statement_error() {
+        let result = parse("\"use strict\"; with (obj) { x; }");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_strict_mode_eval_binding_error() {
+        let result = parse("\"use strict\"; var eval = 1;");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_strict_mode_arguments_binding_error() {
+        let result = parse("\"use strict\"; var arguments = 1;");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_strict_inherited_in_nested_function() {
+        let prog = parse("\"use strict\"; function f() { function g() { return 1; } }").unwrap();
+        assert!(prog.is_strict);
+        if let ProgramItem::Stmt(Stmt::FnDecl(decl)) = &prog.body[1] {
+            // f inherits strict from the program
+            assert!(decl.is_strict);
+        } else {
+            panic!("expected FnDecl");
+        }
     }
 }

--- a/crates/stator_core/src/parser/scope.rs
+++ b/crates/stator_core/src/parser/scope.rs
@@ -159,6 +159,8 @@ pub struct Scope {
     pub uses_super: bool,
     /// Names declared in this scope that are captured by inner function scopes.
     pub captures: HashSet<String>,
+    /// `true` when this scope is in strict mode.
+    pub is_strict: bool,
 }
 
 impl Scope {
@@ -174,6 +176,7 @@ impl Scope {
             uses_this: false,
             uses_super: false,
             captures: HashSet::new(),
+            is_strict: false,
         }
     }
 }
@@ -592,7 +595,11 @@ impl Analyzer {
         } else {
             ScopeKind::Global
         };
-        self.push_scope(kind);
+        let scope_id = self.push_scope(kind);
+        // Modules are always strict; scripts inherit from the AST flag.
+        if program.is_strict || program.source_type == SourceType::Module {
+            self.scopes[scope_id].is_strict = true;
+        }
 
         // Collect top-level var / function hoisted declarations first.
         let stmts: Vec<Stmt> = program
@@ -860,16 +867,13 @@ impl Analyzer {
     }
 
     fn visit_fn_decl(&mut self, f: &FnDecl) {
-        // The function name is already hoisted in the outer scope; here we just
-        // analyse the function body.
-        self.push_scope(ScopeKind::Function);
-        // Declare parameters in the new function scope.
+        let parent_strict = self.scopes[self.current_scope()].is_strict;
+        let scope_id = self.push_scope(ScopeKind::Function);
+        self.scopes[scope_id].is_strict = f.is_strict || parent_strict;
         for param in &f.params {
             self.declare_param(param);
         }
-        // Hoist var/function declarations inside the body.
         self.hoist_stmts(&f.body.body);
-        // Visit the body without creating an extra block scope.
         for stmt in &f.body.body {
             self.visit_stmt(stmt);
         }
@@ -877,8 +881,9 @@ impl Analyzer {
     }
 
     fn visit_fn_expr(&mut self, f: &FnExpr) {
-        self.push_scope(ScopeKind::Function);
-        // A named function expression can self-reference by its name.
+        let parent_strict = self.scopes[self.current_scope()].is_strict;
+        let scope_id = self.push_scope(ScopeKind::Function);
+        self.scopes[scope_id].is_strict = f.is_strict || parent_strict;
         if let Some(id) = &f.id {
             self.declare(
                 &id.name,
@@ -898,11 +903,9 @@ impl Analyzer {
     }
 
     fn visit_arrow_expr(&mut self, a: &crate::parser::ast::ArrowExpr) {
-        // Arrow functions share `this`/`arguments`/`super` with the enclosing
-        // scope, so we still create a new scope but with `Function` kind (the
-        // `is_function_boundary` predicate applies).  For simplicity we use a
-        // dedicated variant — but for this implementation we re-use Function.
-        self.push_scope(ScopeKind::Function);
+        let parent_strict = self.scopes[self.current_scope()].is_strict;
+        let scope_id = self.push_scope(ScopeKind::Function);
+        self.scopes[scope_id].is_strict = a.is_strict || parent_strict;
         for param in &a.params {
             self.declare_param(param);
         }
@@ -1245,6 +1248,7 @@ mod tests {
             loc: loc(),
             source_type: SourceType::Script,
             body: vec![],
+            is_strict: false,
         }
     }
 
@@ -1293,6 +1297,7 @@ mod tests {
             loc: loc(),
             source_type: SourceType::Module,
             body: vec![],
+            is_strict: true,
         };
         let tree = analyze(&prog);
         assert_eq!(tree.scopes[0].kind, ScopeKind::Module);
@@ -1309,6 +1314,7 @@ mod tests {
                 VarKind::Var,
                 "x",
             )))],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         assert!(tree.scopes[0].bindings.contains_key("x"));
@@ -1327,6 +1333,7 @@ mod tests {
             loc: loc(),
             source_type: SourceType::Script,
             body: vec![ProgramItem::Stmt(block)],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         // Global scope (id=0) must contain x.
@@ -1348,11 +1355,13 @@ mod tests {
                 loc: loc(),
                 body: vec![],
             },
+            is_strict: false,
         }));
         let prog = Program {
             loc: loc(),
             source_type: SourceType::Script,
             body: vec![ProgramItem::Stmt(fn_decl)],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         assert!(tree.scopes[0].bindings.contains_key("f"));
@@ -1372,6 +1381,7 @@ mod tests {
             loc: loc(),
             source_type: SourceType::Script,
             body: vec![ProgramItem::Stmt(block)],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         // y must be in the inner block scope, not the global scope.
@@ -1396,6 +1406,7 @@ mod tests {
                 ProgramItem::Stmt(Stmt::VarDecl(var_decl(VarKind::Var, "x"))),
                 ProgramItem::Stmt(Stmt::VarDecl(var_decl(VarKind::Var, "x"))),
             ],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         assert!(
@@ -1413,6 +1424,7 @@ mod tests {
                 ProgramItem::Stmt(Stmt::VarDecl(var_decl(VarKind::Let, "x"))),
                 ProgramItem::Stmt(Stmt::VarDecl(var_decl(VarKind::Let, "x"))),
             ],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         assert_eq!(tree.errors.len(), 1);
@@ -1432,6 +1444,7 @@ mod tests {
                 ProgramItem::Stmt(Stmt::VarDecl(var_decl(VarKind::Const, "C"))),
                 ProgramItem::Stmt(Stmt::VarDecl(var_decl(VarKind::Const, "C"))),
             ],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         assert_eq!(tree.errors.len(), 1);
@@ -1452,6 +1465,7 @@ mod tests {
                 "x",
                 init_expr,
             )))],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         assert!(
@@ -1488,6 +1502,7 @@ mod tests {
             loc: loc(),
             source_type: SourceType::Script,
             body: vec![ProgramItem::Stmt(x_decl), ProgramItem::Stmt(y_decl)],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         assert!(tree.errors.is_empty(), "no TDZ error expected");
@@ -1511,11 +1526,13 @@ mod tests {
                 loc: loc(),
                 body: vec![],
             },
+            is_strict: false,
         }));
         let prog = Program {
             loc: loc(),
             source_type: SourceType::Script,
             body: vec![ProgramItem::Stmt(fn_stmt)],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         // There should be a Function scope.
@@ -1548,6 +1565,7 @@ mod tests {
                     argument: Some(Box::new(ident_expr("x"))),
                 })],
             },
+            is_strict: false,
         }));
         let outer_fn = Stmt::FnDecl(Box::new(FnDecl {
             loc: loc(),
@@ -1559,11 +1577,13 @@ mod tests {
                 loc: loc(),
                 body: vec![Stmt::VarDecl(var_decl(VarKind::Var, "x")), inner_fn],
             },
+            is_strict: false,
         }));
         let prog = Program {
             loc: loc(),
             source_type: SourceType::Script,
             body: vec![ProgramItem::Stmt(outer_fn)],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         // Find the outer function scope (the one that declares x).
@@ -1606,6 +1626,7 @@ mod tests {
             loc: loc(),
             source_type: SourceType::Script,
             body: vec![ProgramItem::Stmt(try_stmt)],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         let catch_scope = tree
@@ -1632,6 +1653,7 @@ mod tests {
             loc: loc(),
             source_type: SourceType::Script,
             body: vec![ProgramItem::Stmt(with_stmt)],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         assert!(tree.scopes.iter().any(|s| s.kind == ScopeKind::With));
@@ -1659,6 +1681,7 @@ mod tests {
                 loc: loc(),
                 expr: Box::new(call),
             }))],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         assert!(tree.scopes[0].uses_eval);
@@ -1675,6 +1698,7 @@ mod tests {
                 loc: loc(),
                 expr: Box::new(Expr::This(ThisExpr { loc: loc() })),
             }))],
+            is_strict: false,
         };
         let tree = analyze(&prog);
         assert!(tree.scopes[0].uses_this);


### PR DESCRIPTION
Implement proper 'use strict' directive detection and enforcement:
- Parse 'use strict' directive prologue in functions and scripts
- Enforce strict mode restrictions: no with statements, no duplicate params
- Assignment to undeclared variables throws ReferenceError
- Delete on unqualified name throws SyntaxError
- Eval/arguments cannot be assigned in strict mode
- Added is_strict to AST nodes, scope analysis propagation
- 8 parser tests added

Closes #383