### PR TITLE
feat: well-known symbol protocol dispatch (closes #390)

### DIFF
--- a/crates/stator_core/src/interpreter/dispatch.rs
+++ b/crates/stator_core/src/interpreter/dispatch.rs
@@ -2522,6 +2522,15 @@ fn handle_test_instance_of(
     };
     let constructor = ctx.frame.read_reg(v)?.clone();
 
+    // §7.3.21 OrdinaryHasInstance — first check @@hasInstance
+    if let JsValue::PlainObject(map) = &constructor
+        && let Some(JsValue::NativeFunction(f)) = map.borrow().get("@@hasInstance").cloned()
+    {
+        let result = f(vec![ctx.frame.accumulator.clone()])?;
+        ctx.frame.accumulator = JsValue::Boolean(result.to_boolean());
+        return Ok(DispatchAction::Continue);
+    }
+
     // Obtain the constructor's "prototype" property.
     let ctor_proto = match &constructor {
         JsValue::PlainObject(map) => map.borrow().get("prototype").cloned(),
@@ -2533,17 +2542,14 @@ fn handle_test_instance_of(
         let mut current = ctx.frame.accumulator.clone();
         let mut found = false;
         for _ in 0..256 {
-            // Check if current is the same object as proto_val
             match &current {
                 JsValue::PlainObject(map) => {
-                    // If this object *is* the prototype, match.
                     if let JsValue::PlainObject(p) = &proto_val
                         && Rc::ptr_eq(map, p)
                     {
                         found = true;
                         break;
                     }
-                    // Walk up via __proto__
                     let next = map.borrow().get("__proto__").cloned();
                     match next {
                         Some(v) => current = v,

--- a/crates/stator_core/src/objects/value.rs
+++ b/crates/stator_core/src/objects/value.rs
@@ -589,8 +589,26 @@ impl JsValue {
             | Self::Symbol(_)
             | Self::BigInt(_) => Ok(self.clone()),
 
-            // PlainObject — check for callable valueOf/toString.
-            Self::PlainObject(map) => ordinary_to_primitive_plain_object(map, hint),
+            // PlainObject — check @@toPrimitive, then OrdinaryToPrimitive.
+            Self::PlainObject(map) => {
+                // §7.1.1 step 2: check for @@toPrimitive method
+                let exotic = map.borrow().get("@@toPrimitive").cloned();
+                if let Some(JsValue::NativeFunction(f)) = exotic {
+                    let hint_str = match hint {
+                        ToPrimitiveHint::String => "string",
+                        ToPrimitiveHint::Number => "number",
+                        ToPrimitiveHint::Default => "default",
+                    };
+                    let result = f(vec![self.clone(), JsValue::String(hint_str.into())])?;
+                    if result.is_primitive() {
+                        return Ok(result);
+                    }
+                    return Err(StatorError::TypeError(
+                        "Symbol.toPrimitive returned a non-primitive".into(),
+                    ));
+                }
+                ordinary_to_primitive_plain_object(map, hint)
+            }
 
             // All other object-like types: default string representation.
             _ => Ok(JsValue::String(self.default_obj_to_string())),
@@ -747,7 +765,13 @@ impl JsValue {
             Self::Iterator(_) => "[object Iterator]".to_string(),
             Self::Error(e) => e.to_error_string(),
             Self::NativeFunction(_) => "function () { [native code] }".to_string(),
-            Self::PlainObject(_) => "[object Object]".to_string(),
+            Self::PlainObject(map) => {
+                // §19.1.3.6: check @@toStringTag
+                if let Some(JsValue::String(tag)) = map.borrow().get("@@toStringTag").cloned() {
+                    return format!("[object {tag}]");
+                }
+                "[object Object]".to_string()
+            }
             Self::Promise(_) => "[object Promise]".to_string(),
             Self::Context(_) => "[object Context]".to_string(),
             Self::Proxy(_) => "[object Object]".to_string(),
@@ -1409,6 +1433,37 @@ mod tests {
         let arr = JsValue::Array(Rc::new(vec![JsValue::Smi(1), JsValue::Smi(2)]));
         let prim = arr.to_primitive(ToPrimitiveHint::String).unwrap();
         assert_eq!(prim, JsValue::String("1,2".to_string()));
+    }
+
+    #[test]
+    fn test_to_primitive_with_symbol_to_primitive() {
+        let mut map = PropertyMap::new();
+        let f: NativeFn = Rc::new(|args| {
+            let hint = args.get(1).unwrap_or(&JsValue::Undefined).clone();
+            if let JsValue::String(h) = hint {
+                Ok(JsValue::String(format!("hint:{h}")))
+            } else {
+                Ok(JsValue::Smi(0))
+            }
+        });
+        map.insert("@@toPrimitive".to_string(), JsValue::NativeFunction(f));
+        let obj = JsValue::PlainObject(Rc::new(RefCell::new(map)));
+        let prim = obj.to_primitive(ToPrimitiveHint::Number).unwrap();
+        assert_eq!(prim, JsValue::String("hint:number".to_string()));
+    }
+
+    #[test]
+    fn test_to_string_tag() {
+        let mut map = PropertyMap::new();
+        map.insert(
+            "@@toStringTag".to_string(),
+            JsValue::String("CustomType".to_string()),
+        );
+        let obj = JsValue::PlainObject(Rc::new(RefCell::new(map)));
+        assert_eq!(
+            obj.default_obj_to_string(),
+            "[object CustomType]".to_string()
+        );
     }
 
     // ── to_number ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Implement Symbol.hasInstance, Symbol.toPrimitive, Symbol.toStringTag:
- @@hasInstance: instanceof operator checks target[Symbol.hasInstance]
- @@toPrimitive: ToPrimitive abstract op checks [Symbol.toPrimitive] first
- @@toStringTag: Object.prototype.toString uses [Symbol.toStringTag]
- Protocol dispatch integrated into interpreter
- Default @@toStringTag for built-in types

Closes #390