### PR TITLE
feat: enable RegExp unicode property escapes + v-flag (closes #396)

### DIFF
--- a/crates/stator_test262/src/main.rs
+++ b/crates/stator_test262/src/main.rs
@@ -284,9 +284,6 @@ impl HarnessCache {
 /// skipped rather than run-and-failed, keeping the measured pass rate
 /// meaningful.
 const UNSUPPORTED_FEATURES: &[&str] = &[
-    // Advanced RegExp features not yet fully supported
-    "regexp-unicode-property-escapes",
-    "regexp-v-flag",
     // Temporal (stage 3 proposal — very large surface area)
     "Temporal",
     // Resizable ArrayBuffer — not yet implemented


### PR DESCRIPTION
Remove regexp-unicode-property-escapes and regexp-v-flag from UNSUPPORTED_FEATURES in test262 runner. The regress v0.10.5 crate already supports unicode property escapes and v-flag features. build_regress_flags already forwards both flags correctly.

Closes #396